### PR TITLE
fix(docker): warn that POSTGRES_PASSWORD must not contain URL-reserved characters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - 3000:3000
     env_file: .env
     environment:
+      # POSTGRES_PASSWORD must not contain URL-reserved characters (/, +, =).
+      # Use: openssl rand -hex 32  — not base64
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
       - DATABASE_DIRECT_URL=${DATABASE_URL}
     depends_on:
@@ -83,6 +85,8 @@ services:
       - NODE_ENV=${NODE_ENV}
       - API_PORT=${API_PORT:-80}
       - API_URL=${API_URL}
+      # POSTGRES_PASSWORD must not contain URL-reserved characters (/, +, =).
+      # Use: openssl rand -hex 32  — not base64
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
       - DATABASE_READ_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
       - DATABASE_WRITE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
@@ -127,6 +131,8 @@ services:
       - 5555:5555
     env_file: .env
     environment:
+      # POSTGRES_PASSWORD must not contain URL-reserved characters (/, +, =).
+      # Use: openssl rand -hex 32  — not base64
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
       - DATABASE_DIRECT_URL=${DATABASE_URL}
     depends_on:
@@ -136,3 +142,4 @@ services:
       - prisma
       - studio
 # END SECTION: Optional use of Prisma Studio.
+


### PR DESCRIPTION
## Problem

`docker-compose.yml` builds `DATABASE_URL` by interpolating `${POSTGRES_PASSWORD}` directly into a `postgresql://` URL:

```yaml
- DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}/${POSTGRES_DB}
```

Passwords generated with `openssl rand -base64 32` contain `/`, `+`, and `=` — URL-reserved characters. When present, `pg-connection-string` (used internally by the Prisma pg adapter) fails to parse the host field and silently falls back to `localhost:5432`, causing:

```
Error: connect ECONNREFUSED 127.0.0.1:5432
```

or the misleading Prisma error:

```
P1001: Can't reach database server at `db`:`5432`
```

(Prisma shows the schema hostname, not the one it actually tried.)

## Fix

Adds a comment before each `DATABASE_URL` line that includes `POSTGRES_PASSWORD` to document the restriction and recommend the safe generator:

```yaml
# POSTGRES_PASSWORD must not contain URL-reserved characters (/, +, =).
# Use: openssl rand -hex 32  — not base64
- DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@...
```

The comment appears in all three services that build the URL inline (`calcom`, `calcom-api`, `studio`).

## Note for entrypoint-based setups

If `DATABASE_URL` is assembled in a shell entrypoint from a Docker Secret, URL-encode the password first:

```sh
_enc="$(printf '%s' "$_pwd" | sed 's/%/%25/g; s/+/%2B/g; s|/|%2F|g; s/=/%3D/g')"
export DATABASE_URL="postgresql://${DB_USER}:${_enc}@db:5432/${DB_NAME}"
```