### PR TITLE
ci(release): harden fork review and GHCR publication

### DIFF
--- a/.ai/decisions.md
+++ b/.ai/decisions.md
@@ -11,8 +11,15 @@ Durable fork decisions:
 - commit creation requires explicit approval
 - secrets must never be printed, copied, committed, or exposed
 - app source changes must be minimal, evidence-based, and reviewed
+- selective upstream intake uses one `git cherry-pick -x` per upstream commit
+- multiple upstream commits must never be squashed into a local aggregate commit
+- partial upstream intake must identify retained/omitted scope in `UPSTREAM_REVIEW_LEDGER.md`
 - downstream secure deployment must prefer reviewed tags or digests over `latest`
 - `secure-docker-blueprint` is a separate consumer repository, not part of this repository
+- manual Docker workflow dispatch is validation-only and cannot publish
+- a release tag must be annotated, match `vX.Y.Z-N`, and point exactly to `origin/release`
+- the exact runtime-tested/scanned image is the image that gets pushed
+- AMD64/ARM64 digests, SBOMs, provenance, and finalizer status are release evidence
 
 AI-layer decision:
 

--- a/.ai/domains/release.md
+++ b/.ai/domains/release.md
@@ -10,6 +10,10 @@ Rules:
 - do not publish images without explicit approval
 - do not assume branch-dispatch test artifacts are trusted releases
 - do not treat `latest` as a safe downstream deployment target
+- manual workflow dispatch is validation-only and must never publish
+- release tags must be annotated, match `vX.Y.Z-N`, and point exactly to `origin/release`
+- publish the exact image that was runtime-tested and scanned; never rebuild between gate and push
+- record architecture-specific registry digests, SBOMs, provenance, and finalizer status
 
 Branch intent reminder:
 

--- a/.ai/index.md
+++ b/.ai/index.md
@@ -6,8 +6,10 @@ Start here, then read the authoritative docs:
 
 - [../AGENTS.md](../AGENTS.md)
 - [../FORK_PROCESS.md](../FORK_PROCESS.md)
+- [../FORK_STATUS.md](../FORK_STATUS.md)
 - [../FORK_STRATEGY.md](../FORK_STRATEGY.md)
 - [../UPSTREAM_SYNC.md](../UPSTREAM_SYNC.md)
+- [../UPSTREAM_REVIEW_LEDGER.md](../UPSTREAM_REVIEW_LEDGER.md)
 - [../RELEASE_PROCESS.md](../RELEASE_PROCESS.md)
 - [../IMAGE_BUILD.md](../IMAGE_BUILD.md)
 - [../SECURITY_REVIEW.md](../SECURITY_REVIEW.md)

--- a/.ai/quality-gates.md
+++ b/.ai/quality-gates.md
@@ -17,6 +17,10 @@ For fork/release work:
 - no image publish without approval
 - no commit without approval
 - `git diff --check`
+- one upstream commit per local `git cherry-pick -x` in the current intake; no new
+  aggregate/squash cherry-picks
+- every reviewed upstream commit has a disposition in `UPSTREAM_REVIEW_LEDGER.md`
+- install/lifecycle scripts leave tracked source clean
 - `scripts/fork-guard-telemetry.sh` — blocking step in `forte-ci`; fails if the removed
   upstream telemetry module, its Jitsu endpoint/key, `next-collect`, or the
   `CALCOM_TELEMETRY_DISABLED` flag reappear through a sync
@@ -41,4 +45,6 @@ Minimum release checks called out in the process layer include:
 - relevant tests
 - reviewed GHCR target
 - recorded image tag or digest
+- tag commit equals the reviewed `origin/release` head
+- AMD64 and ARM64 digests, SBOMs, provenance, and finalizer status are recorded
 - no dependency on `latest` for secure downstream deployment

--- a/.ai/state.md
+++ b/.ai/state.md
@@ -14,13 +14,14 @@ steady-state divergence: [divergence.md](divergence.md).
 - this repo is **public** → never commit real/personal data (company, support address,
   personal logo); those belong in the private deployment
 
-## Status (as of 2026-07-26)
+## Status (as of 2026-08-10)
 
 **Identity:** `cal.forte` — hardened, review-gated fork of Cal.diy (MIT community edition).
-41 fork commits since the upstream base.
+Upstream intake is selective and recorded commit-by-commit in
+[../UPSTREAM_REVIEW_LEDGER.md](../UPSTREAM_REVIEW_LEDGER.md).
 
 **Branches:** `main` = untouched upstream mirror · `develop` = integration/review ·
-`release` = reviewed source for the GHCR image (currently `11cbb281`).
+`release` = reviewed source for the GHCR image (currently `f99367c3`).
 
 **Latest release:** `v6.2.0-4` — `ghcr.io/rubennati/cal.diy:v6.2.0-4`,
 digest `sha256:9818a0be6404bbcf6b330847868d2673ded00b9786ecb6683f49e907cf77a1a8`
@@ -34,6 +35,11 @@ image (Stage 1 + 2).
 [divergence.md](divergence.md)). No runtime behaviour changes, but the Dockerfile did, so
 the next image differs from `v6.2.0-4`. `packages/lib` now type-checks in CI, and four
 orphaned rotted files were deleted.
+
+**Release topology blocker:** `origin/release` ends at `f99367c3` with five historical
+release-only commits and is not an ancestor of `origin/develop`. Complete the one-time
+content-neutral ancestry reconciliation in [../RELEASE_PROCESS.md](../RELEASE_PROCESS.md)
+before the next fast-forward promotion; never force-push `release` to bypass it.
 
 **Security posture:**
 - Security fixes are taken from upstream by default; validate they are *real* fixes
@@ -63,10 +69,12 @@ already removed upstream-side. Details: [branding.md](branding.md).
 
 - Tracks cal.com **6.2.0** (`apps/web/package.json` on `main` and `develop`).
 - Fork divergence point (merge-base `develop`↔`origin/main`): **`46eb533d`**.
-- Mirror `origin/main` at `3894f37`: 44 commits past base, still 6.2.0 patch line. Security
-  fixes among them are cherry-picked; the rest are deferred features/refactors.
+- Mirror `origin/main` last reviewed through `176037d0af`: 50 commits past base, still the
+  6.2.0 patch line. Eight complete upstream patches are integrated, one security fix is
+  prepared locally, and 41 are not integrated. Exact dispositions and historical aggregate
+  provenance are in [../UPSTREAM_REVIEW_LEDGER.md](../UPSTREAM_REVIEW_LEDGER.md).
 - ⚠️ The repo's `v6.2.0` tag points at a **fork** commit (`a39c99f5`), **not** the upstream
-  release. Fork release tags are `v6.2.0-1..-3`. Pin bases to the merge-base / real upstream tag.
+  release. Fork release tags are `v6.2.0-1..-4`. Pin bases to the merge-base / real upstream tag.
 
 ## Knowledge base map
 

--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -1,99 +1,112 @@
-name: "Docker Build and Test"
-description: "Reusable action to build and test Docker images for Cal.com"
+name: "Docker Build, Test, Scan, and Publish"
+description: "Build and validate one cal.forte platform; optionally push the exact validated image"
 
 inputs:
   platform:
-    description: "Target platform (linux/amd64 or arm64)"
+    description: "Target platform (linux/amd64 or linux/arm64)"
     required: true
   platform-suffix:
-    description: "Suffix to add to image tags (e.g., -arm)"
+    description: "Suffix appended to the image tag (for example -arm)"
+    required: false
+    default: ""
+  image-tag:
+    description: "Validated Docker tag without architecture suffix"
+    required: true
+  image-version:
+    description: "Public source version stored in OCI labels"
     required: false
     default: ""
   github-token:
-    description: "GitHub token for GHCR"
-    required: true
+    description: "GitHub token used only when push-image is true"
+    required: false
+    default: ""
   postgres-user:
-    description: "PostgreSQL user"
+    description: "Ephemeral PostgreSQL test user"
     required: true
   postgres-password:
-    description: "PostgreSQL password"
+    description: "Ephemeral PostgreSQL test password"
     required: true
   postgres-db:
-    description: "PostgreSQL database name"
+    description: "Ephemeral PostgreSQL test database"
     required: true
   database-host:
-    description: "Database host"
+    description: "Database host visible to BuildKit"
     required: true
   push-image:
-    description: "Whether to push the built image"
+    description: "Push the exact locally validated image"
     required: false
     default: "false"
-  use-as-latest:
-    description: "Publish as latest"
-    required: false
-    default: "false"
+
+outputs:
+  image_ref:
+    description: "Built image reference"
+    value: ${{ steps.image.outputs.image_ref }}
+  digest:
+    description: "Registry digest of the pushed image; empty for validation-only builds"
+    value: ${{ steps.publish.outputs.digest }}
+  sbom_path:
+    description: "CycloneDX SBOM file"
+    value: ${{ steps.image.outputs.sbom_path }}
 
 runs:
   using: "composite"
   steps:
-    - name: Log in to the Github Container registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.github-token }}
+    - name: Prepare image identity
+      id: image
+      shell: bash
+      env:
+        IMAGE_TAG: ${{ inputs.image-tag }}
+        PLATFORM: ${{ inputs.platform }}
+        PLATFORM_SUFFIX: ${{ inputs.platform-suffix }}
+      run: |
+        set -euo pipefail
 
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: |
-          ghcr.io/rubennati/cal.diy
-        flavor: |
-          latest=${{ !github.event.release.prerelease && inputs.use-as-latest == 'true' }}
-          suffix=${{ inputs.platform-suffix }}
+        if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+          echo "::error::Invalid Docker tag: $IMAGE_TAG"
+          exit 1
+        fi
 
-    - name: Copy env
+        case "$PLATFORM" in
+          linux/amd64) sbom_path="sbom-amd64.cdx.json" ;;
+          linux/arm64) sbom_path="sbom-arm64.cdx.json" ;;
+          *)
+            echo "::error::Unsupported platform: $PLATFORM"
+            exit 1
+            ;;
+        esac
+
+        echo "image_ref=ghcr.io/rubennati/cal.diy:${IMAGE_TAG}${PLATFORM_SUFFIX}" >> "$GITHUB_OUTPUT"
+        echo "sbom_path=$sbom_path" >> "$GITHUB_OUTPUT"
+
+    - name: Start ephemeral database
       shell: bash
       run: |
-        grep -o '^[^#]*' .env.example > .env
-        cat .env >> $GITHUB_ENV
-        echo "DATABASE_HOST=localhost:5432" >> $GITHUB_ENV
-        eval $(sed -e '/^#/d' -e 's/^/export /' -e 's/$/;/' .env) ;
-
-    - name: Start database
-      shell: bash
-      run: |
+        set -euo pipefail
         docker compose up -d database
-
-    - name: Show database logs and container status
-      shell: bash
-      run: |
-        echo "--- Container Status ---"
         docker compose ps database
 
-        echo "--- Container Logs ---"
-        docker compose logs database
-
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       with:
         driver-opts: |
           network=container:database
         buildkitd-flags: |
           --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
 
-    - name: Build image
-      id: docker_build
-      uses: docker/build-push-action@v6
+    - name: Build image once
+      id: docker-build
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: ./
         file: ./Dockerfile
         load: true
         push: false
         platforms: ${{ inputs.platform }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.image.outputs.image_ref }}
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.version=${{ inputs.image-version || inputs.image-tag }}
         build-args: |
           NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
           NEXT_PUBLIC_API_V2_URL=http://localhost:5555/api/v2
@@ -102,57 +115,58 @@ runs:
           DATABASE_URL=postgresql://${{ inputs.postgres-user }}:${{ inputs.postgres-password }}@${{ inputs.database-host }}/${{ inputs.postgres-db }}
           DATABASE_DIRECT_URL=postgresql://${{ inputs.postgres-user }}:${{ inputs.postgres-password }}@${{ inputs.database-host }}/${{ inputs.postgres-db }}
 
-    - name: Test runtime
+    - name: Test exact runtime image
       shell: bash
+      env:
+        IMAGE_REF: ${{ steps.image.outputs.image_ref }}
       run: |
-        tags="${{ steps.meta.outputs.tags }}"
-        IFS=',' read -ra ADDR <<< "$tags"
-        tag=${ADDR[0]}
+        set -euo pipefail
 
-        docker run --rm --network stack \
+        nextauth_secret="$(openssl rand -hex 32)"
+        encryption_key="$(openssl rand -hex 16)"
+        echo "::add-mask::$nextauth_secret"
+        echo "::add-mask::$encryption_key"
+
+        container_name="cal-forte-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        cleanup_container() {
+          docker rm -f "$container_name" >/dev/null 2>&1 || true
+        }
+        trap cleanup_container EXIT
+
+        docker run --detach --name "$container_name" --network stack \
           -p 3000:3000 \
           -e DATABASE_URL=postgresql://${{ inputs.postgres-user }}:${{ inputs.postgres-password }}@database/${{ inputs.postgres-db }} \
           -e DATABASE_DIRECT_URL=postgresql://${{ inputs.postgres-user }}:${{ inputs.postgres-password }}@database/${{ inputs.postgres-db }} \
-          -e NEXTAUTH_SECRET=${{ env.NEXTAUTH_SECRET }} \
-          -e CALENDSO_ENCRYPTION_KEY=${{ env.CALENDSO_ENCRYPTION_KEY }} \
-          $tag &
+          -e NEXTAUTH_SECRET="$nextauth_secret" \
+          -e CALENDSO_ENCRYPTION_KEY="$encryption_key" \
+          "$IMAGE_REF" >/dev/null
 
-          server_pid=$!
+        for attempt in {1..180}; do
+          if [[ "$(docker inspect --format='{{.State.Running}}' "$container_name")" != "true" ]]; then
+            echo "::error::Runtime container exited before becoming healthy"
+            docker logs "$container_name"
+            exit 1
+          fi
 
-          echo "Waiting for the server to start..."
-          sleep 120
+          response="$(curl --connect-timeout 2 --max-time 5 --output /dev/null --silent --write-out '%{http_code}' http://localhost:3000/auth/login || true)"
+          if [[ "$response" == "200" || "$response" == "307" ]]; then
+            echo "Runtime health check passed with HTTP $response"
+            exit 0
+          fi
+          sleep 1
+        done
 
-          echo http://localhost:3000/auth/login
+        echo "::error::Runtime health check timed out"
+        docker logs "$container_name"
+        exit 1
 
-          for i in {1..60}; do
-            echo "Checking server health ($i/60)..."
-            response=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:3000/auth/login)
-            echo "HTTP Status Code: $response"
-            if [[ "$response" == "200" ]] || [[ "$response" == "307" ]]; then
-              echo "Server is healthy"
-              kill $server_pid
-              exit 0
-            fi
-            sleep 1
-          done
-
-          echo "Server health check failed"
-          kill $server_pid
-          exit 1
-      env:
-        NEXTAUTH_SECRET: "EI4qqDpcfdvf4A+0aQEEx8JjHxHSy4uWiZw/F32K+pA="
-        CALENDSO_ENCRYPTION_KEY: "0zfLtY99wjeLnsM7qsa8xsT+Q0oSgnOL"
-
-    # Pre-publish scan of the locally-loaded image (before push). REPORT-ONLY for now
-    # (exit-code 0): the inherited runtime image still ships dev/build tooling + test files
-    # that carry many CVEs, so a hard block would fail every release for things outside our
-    # app. Re-enable blocking (exit-code 1) after the runtime image is slimmed — see
-    # .ai/roadmap.md. Scoped to fixable CRITICAL app-library vulns to keep the log actionable.
-    - name: Scan image for vulnerabilities (Trivy report)
-      uses: aquasecurity/trivy-action@v0.36.0
+    # Report-only until the inherited runtime findings tracked in the slimming plan are
+    # eliminated. This must not be described as a blocking gate in release documentation.
+    - name: Scan image for fixable critical vulnerabilities
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: image
-        image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        image-ref: ${{ steps.image.outputs.image_ref }}
         scanners: vuln
         vuln-type: library
         severity: CRITICAL
@@ -160,31 +174,56 @@ runs:
         exit-code: "0"
         format: table
 
-    - name: Push image
-      id: docker_push
-      uses: docker/build-push-action@v6
-      if: ${{ inputs.push-image == 'true' && !github.event.release.prerelease }}
+    - name: Generate CycloneDX SBOM
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
-        context: ./
-        file: ./Dockerfile
-        push: true
-        platforms: ${{ inputs.platform }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
-          NEXT_PUBLIC_API_V2_URL=http://localhost:5555/api/v2
-          NEXT_PUBLIC_LICENSE_CONSENT=agree
-          NEXT_PUBLIC_APP_NAME=cal.forte
-          DATABASE_URL=postgresql://${{ inputs.postgres-user }}:${{ inputs.postgres-password }}@${{ inputs.database-host }}/${{ inputs.postgres-db }}
-          DATABASE_DIRECT_URL=postgresql://${{ inputs.postgres-user }}:${{ inputs.postgres-password }}@${{ inputs.database-host }}/${{ inputs.postgres-db }}
+        scan-type: image
+        image-ref: ${{ steps.image.outputs.image_ref }}
+        format: cyclonedx
+        output: ${{ steps.image.outputs.sbom_path }}
 
-    - name: Image digest
+    - name: Log in to GHCR
+      if: ${{ inputs.push-image == 'true' }}
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github-token }}
+
+    - name: Refuse to overwrite an existing release tag
+      if: ${{ inputs.push-image == 'true' }}
       shell: bash
-      run: echo ${{ steps.docker_build.outputs.digest }}
+      env:
+        IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+      run: |
+        set -euo pipefail
+        if docker buildx imagetools inspect "$IMAGE_REF" >/dev/null 2>&1; then
+          echo "::error::Image tag already exists and will not be overwritten: $IMAGE_REF"
+          exit 1
+        fi
+
+    - name: Push exact validated image and capture registry digest
+      id: publish
+      if: ${{ inputs.push-image == 'true' }}
+      shell: bash
+      env:
+        IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+      run: |
+        set -euo pipefail
+        docker push "$IMAGE_REF"
+
+        manifest="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .Manifest}}')"
+        digest="$(jq -r '.digest' <<< "$manifest")"
+        if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+          echo "::error::Unable to capture registry digest for $IMAGE_REF"
+          exit 1
+        fi
+
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "Published $IMAGE_REF@$digest" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Cleanup
-      shell: bash
       if: always()
+      shell: bash
       run: |
-        docker compose down
+        docker compose down --volumes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,16 @@ updates:
     schedule:
       interval: weekly
     labels: ["ci"]
+
+  # Immutable base-image digests used by the release and API v2 Dockerfiles.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["docker", "dependencies"]
+
+  - package-ecosystem: docker
+    directory: "/apps/api/v2"
+    schedule:
+      interval: weekly
+    labels: ["docker", "dependencies"]

--- a/.github/workflows/forte-ci.yml
+++ b/.github/workflows/forte-ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [develop, release]
   push:
-    branches: [develop]
+    branches: [develop, release]
 
 permissions:
   contents: read
@@ -21,14 +21,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 20
       - name: Enable corepack (yarn 4)
         run: corepack enable
       - name: Install (immutable)
         run: yarn install --immutable
+      - name: Verify lifecycle scripts did not change tracked source
+        run: |
+          set -euo pipefail
+          if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+            echo "::error::Install or generation changed tracked files"
+            git diff --stat
+            git diff --check
+            exit 1
+          fi
       - name: Fork guard — telemetry stays removed
         # Blocking on purpose: this is the class of regression an upstream sync
         # re-introduces silently. See .ai/divergence.md.

--- a/.github/workflows/forte-codeql.yml
+++ b/.github/workflows/forte-codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [develop, release]
   push:
-    branches: [develop]
+    branches: [develop, release]
   schedule:
     - cron: "17 4 * * 2"
 
@@ -23,11 +23,11 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           languages: javascript-typescript
           queries: security-extended
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/forte-scorecard.yml
+++ b/.github/workflows/forte-scorecard.yml
@@ -21,17 +21,17 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: false
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/forte-trivy.yml
+++ b/.github/workflows/forte-trivy.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches: [develop, release]
   push:
-    branches: [develop]
+    branches: [develop, release]
   schedule:
     - cron: "23 5 * * 1"
 
@@ -23,9 +23,9 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln,secret,misconfig
@@ -35,7 +35,7 @@ jobs:
           output: trivy-fs.sarif
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,129 +1,384 @@
 name: "Release Docker"
 
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
 permissions:
   contents: read
-  packages: write
+
+concurrency:
+  group: release-docker-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   POSTGRES_USER: "unicorn_user"
   POSTGRES_PASSWORD: "magical_password"
   POSTGRES_DB: "calendso"
   DATABASE_HOST: "database:5432"
-
-on:
-  push:
-    tags:
-      - "v*"
-  # in case manual trigger is needed
-  workflow_dispatch:
-    inputs:
-      BUILD_FROM_BRANCH:
-        description: "Build from the selected branch instead of a tag"
-        type: boolean
-        default: false
-      RELEASE_TAG:
-        description: "Tag to build (e.g., v6.0.5) - required if BUILD_FROM_BRANCH is false"
-        required: false
-      PUSH_IMAGE:
-        description: "Push the Docker image to GHCR"
-        type: boolean
-        default: true
+  IMAGE_NAME: "ghcr.io/rubennati/cal.diy"
 
 jobs:
   prepare:
-    name: "Prepare Release"
+    name: "Validate source identity"
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     outputs:
-      release_tag: ${{ steps.determine-tag.outputs.release_tag }}
-      checkout_ref: ${{ steps.determine-tag.outputs.checkout_ref }}
+      checkout_ref: ${{ steps.identity.outputs.checkout_ref }}
+      image_tag: ${{ steps.identity.outputs.image_tag }}
+      source_sha: ${{ steps.identity.outputs.source_sha }}
     steps:
-      - name: Validate inputs
-        if: github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH == false && inputs.RELEASE_TAG == ''
-        run: |
-          echo "::error::RELEASE_TAG is required when BUILD_FROM_BRANCH is false"
-          exit 1
-
-      - name: checkout
-        uses: actions/checkout@v4
+      - name: Checkout requested source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.BUILD_FROM_BRANCH) && github.ref || inputs.RELEASE_TAG || github.ref }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
-      - name: "Determine tag and ref"
-        id: determine-tag
+      - name: Validate release tag or prepare validation identity
+        id: identity
+        shell: bash
         run: |
-          # Determine checkout ref
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
-            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "checkout_ref=${{ inputs.RELEASE_TAG }}" >> $GITHUB_OUTPUT
-          else
-            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-          fi
+          set -euo pipefail
 
-          # Determine release tag
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.BUILD_FROM_BRANCH }}" = "true" ]; then
-              # Extract branch name and short SHA for the tag
-              BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-              # Sanitize branch name: replace all invalid Docker tag characters with dashes
-              # Docker tags can only contain lowercase/uppercase letters, digits, underscores, periods, and dashes
-              # Also remove any leading dashes or periods
-              SANITIZED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9_.-]/-/g' | sed 's/^[-.]*//')
-              SHORT_SHA=$(git rev-parse --short HEAD)
-              echo "release_tag=${SANITIZED_BRANCH}-${SHORT_SHA}" >> $GITHUB_OUTPUT
-            else
-              echo "release_tag=${{ inputs.RELEASE_TAG }}" >> $GITHUB_OUTPUT
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            tag="$GITHUB_REF_NAME"
+            if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[1-9][0-9]*$ ]]; then
+              echo "::error::Release tag must match vX.Y.Z-N: $tag"
+              exit 1
             fi
+
+            git fetch --force origin \
+              refs/heads/release:refs/remotes/origin/release \
+              refs/heads/develop:refs/remotes/origin/develop
+            tag_type="$(git cat-file -t "refs/tags/$tag")"
+            if [[ "$tag_type" != "tag" ]]; then
+              echo "::error::Release tags must be annotated: $tag"
+              exit 1
+            fi
+
+            source_sha="$(git rev-parse "refs/tags/$tag^{}")"
+            release_sha="$(git rev-parse refs/remotes/origin/release)"
+            if [[ "$source_sha" != "$release_sha" ]]; then
+              echo "::error::Tag $tag points to $source_sha, not origin/release HEAD $release_sha"
+              exit 1
+            fi
+
+            release_tree="$(git rev-parse "$release_sha^{tree}")"
+            develop_tree="$(git rev-parse refs/remotes/origin/develop^{tree})"
+            if [[ "$release_tree" != "$develop_tree" ]]; then
+              echo "::error::origin/release source tree is not identical to origin/develop"
+              exit 1
+            fi
+
+            echo "checkout_ref=refs/tags/$tag" >> "$GITHUB_OUTPUT"
+            echo "image_tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+            echo "Validated release tag $tag at $source_sha" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "release_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            source_sha="$(git rev-parse HEAD)"
+            branch="${GITHUB_REF#refs/heads/}"
+            sanitized_branch="$(printf '%s' "$branch" | sed 's/[^a-zA-Z0-9_.-]/-/g' | sed 's/^[-.]*//')"
+            image_tag="validation-${sanitized_branch}-${source_sha:0:10}"
+
+            echo "checkout_ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+            echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+            echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch is validation-only; no image will be published." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-  release-amd64:
-    name: "Release AMD64"
+      - name: Require successful release gates for exact source SHA
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+
+          for workflow in forte-ci.yml forte-codeql.yml forte-trivy.yml; do
+            successful_runs="$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs?branch=release&event=push&status=success&head_sha=$SOURCE_SHA&per_page=10" \
+              --jq '.total_count')"
+            if [[ "$successful_runs" -lt 1 ]]; then
+              echo "::error::No successful $workflow run found for release SHA $SOURCE_SHA"
+              exit 1
+            fi
+          done
+
+  validate-amd64:
+    name: "Validate AMD64"
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: prepare
     runs-on: ubuntu-latest
-    env:
-      RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+    permissions:
+      contents: read
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
+      - name: Checkout validated source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
-      - name: Build and test Docker image
+      - name: Build, test, and scan without publishing
+        id: image
         uses: ./.github/actions/docker-build-and-test
         with:
           platform: "linux/amd64"
           platform-suffix: ""
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          image-tag: ${{ needs.prepare.outputs.image_tag }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
           postgres-db: ${{ env.POSTGRES_DB }}
           database-host: ${{ env.DATABASE_HOST }}
-          push-image: ${{ (github.event_name == 'push' || inputs.PUSH_IMAGE) && 'true' || 'false' }}
-          use-as-latest: "true"
+          push-image: "false"
 
+      - name: Upload AMD64 SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: validation-sbom-amd64-${{ needs.prepare.outputs.source_sha }}
+          path: ${{ steps.image.outputs.sbom_path }}
+          if-no-files-found: error
 
-  release-arm:
-    name: "Release ARM"
+  validate-arm64:
+    name: "Validate ARM64"
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: prepare
     runs-on: ubuntu-24.04-arm
-    env:
-      RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+    permissions:
+      contents: read
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
+      - name: Checkout validated source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
-      - name: Build and test Docker image
+      - name: Build, test, and scan without publishing
+        id: image
         uses: ./.github/actions/docker-build-and-test
         with:
-          platform: "arm64"
+          platform: "linux/arm64"
           platform-suffix: "-arm"
+          image-tag: ${{ needs.prepare.outputs.image_tag }}
+          postgres-user: ${{ env.POSTGRES_USER }}
+          postgres-password: ${{ env.POSTGRES_PASSWORD }}
+          postgres-db: ${{ env.POSTGRES_DB }}
+          database-host: ${{ env.DATABASE_HOST }}
+          push-image: "false"
+
+      - name: Upload ARM64 SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: validation-sbom-arm64-${{ needs.prepare.outputs.source_sha }}
+          path: ${{ steps.image.outputs.sbom_path }}
+          if-no-files-found: error
+
+  release-amd64:
+    name: "Release AMD64"
+    if: ${{ github.event_name == 'push' }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.image.outputs.image_ref }}
+      digest: ${{ steps.image.outputs.digest }}
+    steps:
+      - name: Checkout validated release tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
+
+      - name: Build, test, scan, and publish exact AMD64 image
+        id: image
+        uses: ./.github/actions/docker-build-and-test
+        with:
+          platform: "linux/amd64"
+          platform-suffix: "-amd64"
+          image-tag: staging-${{ github.run_id }}-${{ github.run_attempt }}
+          image-version: ${{ needs.prepare.outputs.image_tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
           postgres-db: ${{ env.POSTGRES_DB }}
           database-host: ${{ env.DATABASE_HOST }}
-          push-image: ${{ (github.event_name == 'push' || inputs.PUSH_IMAGE) && 'true' || 'false' }}
+          push-image: "true"
+
+      - name: Upload AMD64 SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-sbom-amd64-${{ needs.prepare.outputs.image_tag }}
+          path: ${{ steps.image.outputs.sbom_path }}
+          if-no-files-found: error
+
+  release-arm64:
+    name: "Release ARM64"
+    if: ${{ github.event_name == 'push' }}
+    needs: prepare
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.image.outputs.image_ref }}
+      digest: ${{ steps.image.outputs.digest }}
+    steps:
+      - name: Checkout validated release tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
+
+      - name: Build, test, scan, and publish exact ARM64 image
+        id: image
+        uses: ./.github/actions/docker-build-and-test
+        with:
+          platform: "linux/arm64"
+          platform-suffix: "-arm"
+          image-tag: staging-${{ github.run_id }}-${{ github.run_attempt }}
+          image-version: ${{ needs.prepare.outputs.image_tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          postgres-user: ${{ env.POSTGRES_USER }}
+          postgres-password: ${{ env.POSTGRES_PASSWORD }}
+          postgres-db: ${{ env.POSTGRES_DB }}
+          database-host: ${{ env.DATABASE_HOST }}
+          push-image: "true"
+
+      - name: Upload ARM64 SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-sbom-arm64-${{ needs.prepare.outputs.image_tag }}
+          path: ${{ steps.image.outputs.sbom_path }}
+          if-no-files-found: error
+
+  finalize-release:
+    name: "Finalize release evidence and latest"
+    if: ${{ github.event_name == 'push' }}
+    needs: [prepare, release-amd64, release-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Publish final architecture tags and latest
+        id: publish_tags
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          STAGING_AMD64_REF: ${{ needs.release-amd64.outputs.image_ref }}
+          STAGING_AMD64_DIGEST: ${{ needs.release-amd64.outputs.digest }}
+          STAGING_ARM64_REF: ${{ needs.release-arm64.outputs.image_ref }}
+          STAGING_ARM64_DIGEST: ${{ needs.release-arm64.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          final_amd64_ref="$IMAGE_NAME:$RELEASE_TAG"
+          final_arm64_ref="$IMAGE_NAME:$RELEASE_TAG-arm"
+
+          docker buildx imagetools inspect "$STAGING_AMD64_REF@$STAGING_AMD64_DIGEST" >/dev/null
+          docker buildx imagetools inspect "$STAGING_ARM64_REF@$STAGING_ARM64_DIGEST" >/dev/null
+
+          for final_ref in "$final_amd64_ref" "$final_arm64_ref"; do
+            if docker buildx imagetools inspect "$final_ref" >/dev/null 2>&1; then
+              echo "::error::Final release tag already exists and will not be overwritten: $final_ref"
+              exit 1
+            fi
+          done
+
+          docker buildx imagetools create \
+            --tag "$final_amd64_ref" \
+            "$STAGING_AMD64_REF@$STAGING_AMD64_DIGEST"
+          docker buildx imagetools create \
+            --tag "$final_arm64_ref" \
+            "$STAGING_ARM64_REF@$STAGING_ARM64_DIGEST"
+
+          amd64_manifest="$(docker buildx imagetools inspect "$final_amd64_ref" --format '{{json .Manifest}}')"
+          arm64_manifest="$(docker buildx imagetools inspect "$final_arm64_ref" --format '{{json .Manifest}}')"
+          amd64_digest="$(jq -r '.digest' <<< "$amd64_manifest")"
+          arm64_digest="$(jq -r '.digest' <<< "$arm64_manifest")"
+
+          if [[ ! "$amd64_digest" =~ ^sha256:[a-f0-9]{64}$ || ! "$arm64_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "::error::Unable to capture final architecture digests"
+            exit 1
+          fi
+
+          docker buildx imagetools create --tag "$IMAGE_NAME:latest" "$final_amd64_ref@$amd64_digest"
+          latest_manifest="$(docker buildx imagetools inspect "$IMAGE_NAME:latest" --format '{{json .Manifest}}')"
+          latest_digest="$(jq -r '.digest' <<< "$latest_manifest")"
+
+          echo "amd64_ref=$final_amd64_ref" >> "$GITHUB_OUTPUT"
+          echo "amd64_digest=$amd64_digest" >> "$GITHUB_OUTPUT"
+          echo "arm64_ref=$final_arm64_ref" >> "$GITHUB_OUTPUT"
+          echo "arm64_digest=$arm64_digest" >> "$GITHUB_OUTPUT"
+          echo "latest_digest=$latest_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Attest final AMD64 build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.publish_tags.outputs.amd64_digest }}
+          push-to-registry: true
+
+      - name: Attest final ARM64 build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.publish_tags.outputs.arm64_digest }}
+          push-to-registry: true
+
+      - name: Write release record
+        id: record
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          AMD64_REF: ${{ steps.publish_tags.outputs.amd64_ref }}
+          AMD64_DIGEST: ${{ steps.publish_tags.outputs.amd64_digest }}
+          ARM64_REF: ${{ steps.publish_tags.outputs.arm64_ref }}
+          ARM64_DIGEST: ${{ steps.publish_tags.outputs.arm64_digest }}
+          LATEST_DIGEST: ${{ steps.publish_tags.outputs.latest_digest }}
+          STAGING_AMD64_REF: ${{ needs.release-amd64.outputs.image_ref }}
+          STAGING_ARM64_REF: ${{ needs.release-arm64.outputs.image_ref }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg tag "$RELEASE_TAG" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg amd64_ref "$AMD64_REF" \
+            --arg amd64_digest "$AMD64_DIGEST" \
+            --arg arm64_ref "$ARM64_REF" \
+            --arg arm64_digest "$ARM64_DIGEST" \
+            --arg latest_digest "$LATEST_DIGEST" \
+            --arg staging_amd64 "$STAGING_AMD64_REF" \
+            --arg staging_arm64 "$STAGING_ARM64_REF" \
+            --arg workflow_run "$GITHUB_RUN_ID" \
+            '{tag: $tag, source_sha: $source_sha, amd64: {image: $amd64_ref, digest: $amd64_digest, staging_image: $staging_amd64}, arm64: {image: $arm64_ref, digest: $arm64_digest, staging_image: $staging_arm64}, latest_digest: $latest_digest, workflow_run: $workflow_run}' \
+            > release-record.json
+
+          {
+            echo "## Published release $RELEASE_TAG"
+            echo
+            echo "- Source: \`$SOURCE_SHA\`"
+            echo "- AMD64: \`$AMD64_REF@$AMD64_DIGEST\`"
+            echo "- ARM64: \`$ARM64_REF@$ARM64_DIGEST\`"
+            echo "- latest (convenience only): \`$IMAGE_NAME:latest@$LATEST_DIGEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-record-${{ needs.prepare.outputs.image_tag }}
+          path: release-record.json
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Durable fork rules:
 - no upstream sync, image publish, or commit without explicit approval
 - app source changes must be minimal, evidence-based, and reviewed
 - security-relevant upstream commits are taken by default (see UPSTREAM_SYNC.md → Security Fix Priority)
+- selective upstream intake is one upstream commit per local `git cherry-pick -x`; never
+  squash multiple upstream commits into a local aggregate commit
 - secrets must never be printed, copied, committed, or exposed
 - **do NOT add the `Co-Authored-By: Claude` trailer to commits in this repo**
 - `secure-docker-blueprint` is a separate consumer repo; do not treat `latest` as a secure deploy target
@@ -47,6 +49,7 @@ Durable fork rules:
 - Never use `as any` - use proper type-safe solutions instead
 - Never expose `credential.key` field in API responses or queries
 - Never commit secrets or API keys
+- Never combine multiple upstream commits into one local cherry-pick/squash commit
 - Never modify `*.generated.ts` files directly - they're created by app-store-cli
 - Never put business logic in repositories - that belongs in Services
 - Never use barrel imports from index.ts files

--- a/CALDIY_RELEASE_CONTRACT.md
+++ b/CALDIY_RELEASE_CONTRACT.md
@@ -8,12 +8,17 @@ An image from this fork may be used by `secure-docker-blueprint` only when all o
 - source branch is `release`
 - source commit SHA is recorded
 - upstream source commit or tag is recorded
+- release tag is annotated, matches `vX.Y.Z-N`, and points exactly to `origin/release` head
 
 ## Review State
 
 - the diff is understood
 - fork-only commits are identified
 - no unexplained application-source drift is present
+- every upstream commit is represented in `UPSTREAM_REVIEW_LEDGER.md`
+- no new intake collapsed multiple upstream commits into an aggregate local commit; the
+  immutable historical exception `75c8f5c18f` is fully mapped in the ledger
+- partial upstream intake is explicitly scoped and justified
 
 ## Checks
 
@@ -21,12 +26,17 @@ An image from this fork may be used by `secure-docker-blueprint` only when all o
 - relevant tests completed
 - `git diff --check` completed
 - release workflow target was reviewed
+- install/lifecycle scripts left tracked source unchanged
+- non-publishing AMD64 and ARM64 image validation completed
 
 ## Artifact Rules
 
 - the artifact came from the fork GHCR path
 - the version tag is recorded
 - the image digest is recorded
+- separate AMD64 and ARM64 image references/digests are recorded
+- SBOM artifacts and build-provenance attestations are recorded
+- the release finalization job completed after both architectures
 - downstream secure deployment will use the reviewed tag or digest
 - downstream secure deployment will not rely on `latest`
 
@@ -35,6 +45,8 @@ An image from this fork may be used by `secure-docker-blueprint` only when all o
 - no upstream sync was performed blindly as part of the release
 - no release image was accepted without documenting known risks
 - rollback target is a previous reviewed tag or digest
+- manual workflow dispatch did not publish an image
+- an existing release tag or GHCR version tag was not overwritten
 
 ## Release Record Template
 
@@ -44,8 +56,13 @@ source branch:
 source commit:
 upstream base:
 fork-only commits:
-image:
-digest:
+amd64 image:
+amd64 digest:
+arm64 image:
+arm64 digest:
+workflow run:
+SBOM artifacts:
+provenance attestations:
 checks:
 notes:
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,13 @@ ENV NODE_ENV=production
 ENV GOOGLE_ADS_ENABLED=0 \
   LINKEDIN_ADS_ENABLED=0
 
+# Runtime URL replacement and Turbo/Next caches need these paths writable without granting
+# ownership of the complete application tree.
+RUN mkdir -p /calcom/.turbo \
+  && chown -R node:node /calcom/.turbo /calcom/apps/web/.next /calcom/apps/web/public
+
+USER node
+
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=30s --retries=5 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:20 AS builder
+FROM --platform=$BUILDPLATFORM node:20@sha256:8f693eaa7e0a8e71560c9a82b55fd54c2ae920a2ba5d2cde28bac7d1c01c9ba5 AS builder
 
 WORKDIR /calcom
 
@@ -48,8 +48,7 @@ COPY apps/api/v2 ./apps/api/v2
 COPY packages ./packages
 
 RUN yarn config set httpTimeout 1200000
-RUN npx turbo prune --scope=@calcom/web --scope=@calcom/trpc --docker
-RUN yarn install
+RUN yarn install --immutable
 # Build and make embed servable from web/public/embed folder
 RUN yarn workspace @calcom/trpc run build
 RUN yarn --cwd packages/embeds/embed-core workspace @calcom/embed-core run build
@@ -57,7 +56,7 @@ RUN yarn --cwd apps/web workspace @calcom/web run copy-app-store-static
 RUN yarn --cwd apps/web workspace @calcom/web run build
 RUN rm -rf node_modules/.cache .yarn/cache apps/web/.next/cache
 
-FROM node:20 AS builder-two
+FROM node:20@sha256:8f693eaa7e0a8e71560c9a82b55fd54c2ae920a2ba5d2cde28bac7d1c01c9ba5 AS builder-two
 
 WORKDIR /calcom
 ARG NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
@@ -95,7 +94,7 @@ RUN rm -rf \
   node_modules/@biomejs \
   || true
 
-FROM node:20 AS runner
+FROM node:20@sha256:8f693eaa7e0a8e71560c9a82b55fd54c2ae920a2ba5d2cde28bac7d1c01c9ba5 AS runner
 
 WORKDIR /calcom
 

--- a/FORK_PROCESS.md
+++ b/FORK_PROCESS.md
@@ -26,6 +26,8 @@ The goal is a simple operating model:
 - `release`
   - Release branch for reviewed tags and GHCR publication.
   - Every commit on this branch should have a clear reason to be shippable.
+  - Target state: the tagged source tree is identical to the approved `develop` candidate;
+    release-only application or workflow edits are forbidden.
 - tags
   - Tags represent reviewed release points.
   - Tags are the release inputs that downstream secure deployment should trust.
@@ -63,18 +65,27 @@ Areas that should not drift casually:
   - checks performed
   - resulting image tag
   - resulting image digest
+- A release tag must point exactly to the current reviewed `origin/release` head.
+- Manual branch validation must never publish an image.
+- A release is incomplete until AMD64, ARM64, provenance/SBOM, digest capture, and the
+  finalization job have all succeeded.
 
 ## Normal Operating Cycle
 
 1. Inspect upstream changes.
-2. Update `main` to the desired upstream state.
-3. Merge or rebase that state into `develop`.
+2. Update `main` to the observed upstream state.
+3. Integrate approved upstream commits one at a time with `git cherry-pick -x`, or perform
+   an explicitly approved history-preserving release-base merge without squashing.
 4. Review the diff, especially fork-owned paths and security-sensitive areas.
 5. Run release gates.
 6. Promote reviewed code to `release`.
 7. Create a release tag from `release`.
 8. Publish the GHCR image from that tag.
 9. Record the resulting digest and release notes.
+
+Every upstream decision is recorded in [UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md).
+Historical aggregate commit `75c8f5c18f` is documented there and must not be used as a
+precedent.
 
 ## Things This Repository Should Not Assume
 

--- a/FORK_STATUS.md
+++ b/FORK_STATUS.md
@@ -3,7 +3,9 @@
 This page records the public maintenance status of `cal.forte`: which upstream state was
 seen and reviewed, which changes were actually integrated, and which source produced the
 latest release. It complements the chronological [sync log](.ai/sync-log.md) and the
-steady-state [divergence record](.ai/divergence.md).
+steady-state [divergence record](.ai/divergence.md). Commit-level accepted, partial,
+deferred, and rejected decisions are recorded in
+[UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md).
 
 ## Current Snapshot
 
@@ -89,6 +91,9 @@ defined in [CALDIY_RELEASE_CONTRACT.md](CALDIY_RELEASE_CONTRACT.md).
 
 ## Known Limitations
 
+- `origin/release` has five historical release-only commits and is not yet an ancestor of
+  `origin/develop`; the one-time, content-neutral ancestry reconciliation in
+  [RELEASE_PROCESS.md](RELEASE_PROCESS.md) is required before the next fast-forward release.
 - `type-check:ci` does not cover every workspace package; see
   [.ai/quality-gates.md](.ai/quality-gates.md).
 - The Trivy image scan is currently report-only while inherited runtime-image findings are
@@ -106,6 +111,7 @@ Record the detailed outcome in [.ai/sync-log.md](.ai/sync-log.md), including:
 - review date, start commit, and end commit
 - accepted and integrated commits
 - intentionally deferred commits and reasons
+- ledger status and local provenance for every reviewed upstream commit
 - checks run and known validation gaps
 - release tag, source commit, workflow run, image references, and digest when published
 

--- a/FORK_STRATEGY.md
+++ b/FORK_STRATEGY.md
@@ -38,8 +38,9 @@ Record the base tag in each [sync-log](.ai/sync-log.md) entry.
 
 1. List what changed since our base: `git log --oneline <base>..origin/main`.
 2. Classify each commit: **security** / **interface-we-depend-on** / **feature-or-other**.
-3. Take security + required-interface; defer the rest and record why.
-4. Security scan command: [UPSTREAM_SYNC.md](UPSTREAM_SYNC.md) → Security Fix Priority.
+3. Record every commit in [UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md).
+4. Take security + required-interface; defer the rest and record why.
+5. Security scan command: [UPSTREAM_SYNC.md](UPSTREAM_SYNC.md) → Security Fix Priority.
 
 ## Security-fix validation (don't trust the commit subject)
 
@@ -53,8 +54,20 @@ is a real, relevant fix:
   mark it N/A rather than taking it blindly.
 - **Dependency bumps:** confirm the package is actually used and the advisory applies
   (direct vs transitive).
-- Cherry-pick with `-x` (records the upstream SHA); add the CVE/GHSA id to the message
-  when one exists.
+- Cherry-pick one upstream commit at a time with `-x` (records the upstream SHA); add the
+  CVE/GHSA id to the message when one exists.
+
+## Commit provenance and partial intake
+
+- Never squash multiple upstream commits into one local commit.
+- Keep fork-specific adaptations in a separate follow-up commit that names the upstream SHA.
+- If only part of an upstream change is suitable, record it as `partial` in
+  [UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md), including retained and omitted
+  behavior. Do not label a hand-selected patch as a full cherry-pick.
+- A deliberate full upstream release merge may preserve the original upstream commits and
+  merge topology. It must not replace them with one synthetic aggregate commit.
+- Historical aggregate commit `75c8f5c18f` remains immutable; its four complete upstream
+  patches are mapped individually in the ledger and the pattern must not be repeated.
 
 ## Cadence
 

--- a/IMAGE_BUILD.md
+++ b/IMAGE_BUILD.md
@@ -1,95 +1,87 @@
 # Image Build
 
-## Purpose
+## Source Of Truth
 
-This document describes the current image build assets in this repository and the intended release source of truth.
+The deployable artifact is the GHCR image produced from a validated annotated tag on
+`release` by [.github/workflows/release-docker.yaml](.github/workflows/release-docker.yaml).
+The root [Dockerfile](Dockerfile) builds the web image; the API v2 Dockerfile is not part of
+the current fork release artifact.
 
-## Current Build Assets
+## Workflow Modes
 
-Web image build:
+### Manual validation
 
-- [Dockerfile](/Users/rb3nt/Code/cal.diy/Dockerfile:1)
+`workflow_dispatch` checks out the selected ref and builds AMD64 and ARM64 with synthetic
+validation tags. It runtime-tests, scans, and generates SBOMs but has read-only package
+permissions and cannot publish.
 
-API v2 image build:
+### Tag publication
 
-- [apps/api/v2/Dockerfile](/Users/rb3nt/Code/cal.diy/apps/api/v2/Dockerfile:1)
+A pushed tag publishes only if all source-identity checks pass:
 
-Release workflow:
+- annotated tag
+- exact `vX.Y.Z-N` format
+- tag commit equals current `origin/release` HEAD
+- no existing architecture tag would be overwritten
 
-- [.github/workflows/release-docker.yaml](/Users/rb3nt/Code/cal.diy/.github/workflows/release-docker.yaml:1)
+Architecture jobs push the exact tested images under unique workflow staging tags. Only
+after both succeed does the finalizer create `vX.Y.Z-N` for AMD64 and `vX.Y.Z-N-arm` for
+ARM64. The finalizer then moves `latest` to AMD64. Registry retagging is not transactional:
+if finalization fails between tag operations, treat the release as incomplete and inspect
+all public tags before retrying. `latest` is convenience only and is not a downstream trust
+input.
 
-Reusable build helper:
+## Artifact Integrity
 
-- [.github/actions/docker-build-and-test/action.yml](/Users/rb3nt/Code/cal.diy/.github/actions/docker-build-and-test/action.yml:1)
+Each architecture is built once. The same local image is runtime-tested, scanned, assigned
+an SBOM, and then pushed with `docker push`; there is no second untested rebuild. The
+registry digest is read after push and exposed as a job output.
 
-## Current Release Source Of Truth
+The release finalizer uploads `release-record.json` containing source SHA, architecture
+image references, architecture digests, workflow run ID, and the convenience `latest`
+digest. GitHub build-provenance attestations are pushed for both architecture images.
 
-For the fork release process, the source of truth is the GHCR image produced by the release workflow from a reviewed tag on `release`.
+## Current Security Gates
 
-That means:
+- Runtime health check: blocking.
+- Existing-tag overwrite protection: blocking.
+- Tag/source identity validation: blocking.
+- `forte-ci` install/source-clean check, fork guard, and typecheck: blocking.
+- Trivy image scan: **report-only** (`exit-code: 0`) while inherited runtime findings remain.
+- Biome in `forte-ci`: report-only until inherited baseline findings are resolved.
 
-- the workflow output is the deployable artifact
-- the tag identifies the reviewed source state
-- the digest identifies the exact image to deploy
+Do not describe report-only checks as release gates. Accepted findings and re-enable
+conditions are tracked in [.ai/slimming-runtime-plan.md](.ai/slimming-runtime-plan.md).
 
-## Current Behavior Summary
+## Reproducibility Rules
 
-- The release builds both amd64 and arm64 but publishes them as **separate tags**
-  (`vX.Y.Z` = amd64, `vX.Y.Z-arm` = arm64) — there is no merged multi-arch manifest, so
-  `vX.Y.Z` alone resolves to amd64 (confirmed on `v6.2.0-2`). arm64 consumers must pin
-  the `-arm` tag. A true multi-arch manifest would need a manifest-merge step; not needed for now.
-- A **Trivy image-gate** in the reusable action scans the built image before the push
-  step and blocks the publish on fixable CRITICAL vulnerabilities (exceptions via `.trivyignore`).
-- The reusable action publishes to `ghcr.io/rubennati/cal.diy`.
-- The workflow currently builds from the root [Dockerfile](/Users/rb3nt/Code/cal.diy/Dockerfile:1).
-- The API v2 Dockerfile exists, but it is not the current fork GHCR release artifact.
+- Yarn installs use `--immutable`.
+- Docker builds must not download an unpinned build CLI through `npx`.
+- Lifecycle generation must leave tracked source clean; `forte-ci` fails otherwise.
+- Base images and third-party Actions should be pinned to immutable digests/commit SHAs and
+  updated deliberately.
+- Build args contain synthetic test/database values only; runtime secrets are generated per
+  workflow run and masked.
+- `.env.example` is not evaluated as shell code by the release workflow.
 
-## Release Guidance
+## Downstream Handoff
 
-- Use reviewed version tags for release publication.
-- Prefer digests for downstream secure deployment.
-- Do not rely on `latest` for secure deployment.
-- Treat branch-based workflow dispatch outputs as test artifacts unless explicitly promoted later.
-
-## Build Inputs To Watch
-
-During every release review, inspect:
-
-- workflow tag source
-- image name and registry
-- build arguments
-- runtime environment expectations
-- test step behavior
-- whether any secret-like value is used during build
-
-## Current Known Follow-Up Items
-
-These are not changed in this pass, but they should be corrected later:
-
-- README still references upstream DockerHub
-- docker docs still reference upstream DockerHub
-- `docker-compose.yml` still points at upstream image names
-- workflow wording still needs to stay aligned with actual GHCR behavior
-
-## What This Repository Should Hand To Downstream
-
-Downstream secure deployment should receive:
-
-- reviewed release tag
-- GHCR image reference
-- image digest
-- short release note describing the source commit and checks run
-
-## Practical Release Output Format
-
-Use a simple release record like:
+Provide:
 
 ```text
-tag: vX.Y.Z
-source branch: release
-source commit: <sha>
-upstream base: <sha-or-tag>
-image: ghcr.io/rubennati/cal.diy:vX.Y.Z
-digest: sha256:<digest>
-checks: type-check, tests, smoke-check
+tag:
+source commit:
+amd64 image:
+amd64 digest:
+arm64 image:
+arm64 digest:
+workflow run:
+SBOM artifacts:
+provenance attestations:
+checks:
+known risks:
+rollback digest:
 ```
+
+`secure-docker-blueprint` chooses the required architecture and pins the corresponding
+digest. It remains a separate repository with separate deployment responsibility.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Everything we know about this fork, grouped. Entry point for tooling: [.ai/index
 | [FORK_PROCESS.md](FORK_PROCESS.md) | branch contract & operating cycle |
 | [FORK_STRATEGY.md](FORK_STRATEGY.md) | maintenance model, security-fix validation, sync cadence |
 | [UPSTREAM_SYNC.md](UPSTREAM_SYNC.md) | how upstream is pulled in (security-first) |
+| [UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md) | commit-level accepted, partial, deferred and rejected upstream changes |
 | [RELEASE_PROCESS.md](RELEASE_PROCESS.md) · [IMAGE_BUILD.md](IMAGE_BUILD.md) | cutting & building a release |
 | [SECURITY_REVIEW.md](SECURITY_REVIEW.md) · [CALDIY_RELEASE_CONTRACT.md](CALDIY_RELEASE_CONTRACT.md) | review gate & downstream trust |
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -2,104 +2,155 @@
 
 ## Purpose
 
-This document describes how a reviewed state in this fork becomes a tagged GHCR image.
+This runbook defines how a reviewed `develop` state becomes an immutable release tag and a
+traceable GHCR image. Publication is approval-gated and never happens from manual branch
+validation.
 
-## Release Inputs
+## Release Invariants
 
-Before starting a release:
+- `main` is the upstream mirror, `develop` is integration/review, and `release` is the
+  reviewed publication branch.
+- Upstream commits remain individually traceable; selective intake uses one
+  `git cherry-pick -x` per upstream commit and never a squash aggregate.
+- The tagged `release` source tree must equal the approved `develop` candidate tree.
+- A release tag must match `vX.Y.Z-N`, be annotated, and point exactly to
+  `origin/release` HEAD.
+- Version tags and GHCR tags are immutable identities and must not be overwritten.
+- Manual workflow dispatch is validation-only and cannot publish.
+- `latest` is convenience metadata, updated only after both architecture jobs succeed;
+  downstream must never rely on it.
 
-- `develop` contains the reviewed candidate state
-- release gates have passed
-- the `develop...release` delta is understood
-- the intended version tag is known
-- the operator is ready to record the image digest after publish
+## 1. Prepare The Candidate On `develop`
 
-## Branch Flow
+1. Confirm the worktree is clean and `develop` matches `origin/develop`.
+2. Reconcile [UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md).
+3. Review every commit pending for release and every fork-owned conflict/adaptation.
+4. Run:
 
-The intended release flow is:
+```bash
+YARN_ENABLE_SCRIPTS=false corepack yarn install --immutable
+corepack yarn type-check:ci --force
+git diff --check
+```
 
-1. review `develop`
-2. promote that reviewed state to `release`
-3. tag `release`
-4. let the GHCR workflow build and publish from the tag
-5. capture the digest
-6. give downstream deployment the tag and digest
+5. Run focused tests for changed security/runtime paths.
+6. Run `forte-ci`, CodeQL, and Trivy on `develop` and record known non-blocking findings.
+7. Run `Release Docker` manually on `develop`. This builds, runtime-tests, scans, and
+   produces SBOM artifacts for AMD64 and ARM64, but cannot publish.
 
-## Promotion Rules
+## 2. Promote To `release`
 
-- `release` should represent a reviewed, shippable state.
-- If `release` is behind `develop`, update `release` deliberately.
-- Do not add unrelated edits during release promotion.
-- Prefer a simple promotion path that is easy to audit later.
+The target model is a source-identical promotion. Do not edit files during promotion.
 
-## Tagging Rules
+### One-time historical ancestry reconciliation
 
-- Create versioned tags from `release`.
-- Treat tags as immutable release identities.
-- Keep release notes tied to the exact tag.
+As of 2026-08-10, `origin/release` has five release-only commits ending at `f99367c3a7`
+and is not an ancestor of `origin/develop`. Therefore the first promotion under this
+process cannot fast-forward until that topology is reconciled. Do not force-push or reset
+the protected `release` branch.
 
-## Current Workflow Shape
+Use a dedicated reviewed branch from the then-current `origin/develop`. Record the old
+release history as ancestry with an **ours-strategy merge**; this preserves the reviewed
+`develop` tree while making `origin/release` an ancestor:
 
-The current release workflow is:
+```bash
+git fetch origin --prune --tags
+git switch --create codex/reconcile-release-ancestry origin/develop
+git merge --strategy=ours --no-ff origin/release \
+  -m "chore(release): reconcile historical release ancestry"
+git diff --exit-code HEAD^1..HEAD
+git merge-base --is-ancestor origin/release HEAD
+```
 
-- [.github/workflows/release-docker.yaml](/Users/rb3nt/Code/cal.diy/.github/workflows/release-docker.yaml:1)
+The empty-tree merge commit must be reviewed, pass all `develop` gates, and reach
+`origin/develop` through the normal approved push/PR path. Only then use the fast-forward
+promotion below. This is a one-time topology repair, not a general release technique.
 
-The reusable build helper is:
+### Normal fast-forward promotion
 
-- [.github/actions/docker-build-and-test/action.yml](/Users/rb3nt/Code/cal.diy/.github/actions/docker-build-and-test/action.yml:1)
+```bash
+git fetch origin --prune --tags
+git switch release
+git merge --ff-only origin/develop
+git diff --exit-code origin/develop..release
+git push origin release
+```
 
-The workflow already publishes to:
+If fast-forward is impossible, stop. Do not create an ad-hoc release merge or resolve
+conflicts during promotion. Reconcile branch history deliberately on `develop`, rerun all
+gates, and try again.
 
-- `ghcr.io/rubennati/cal.diy`
+Until the one-time reconciliation is complete, stop before promotion. Do not replace the
+fast-forward with a release-side merge merely because `--ff-only` fails.
 
-## Release Modes
+## 3. Verify Before Tagging
 
-### Official release mode
+```bash
+git fetch origin --prune --tags
+git diff --exit-code origin/develop..origin/release
+git status --short --branch
+git log --oneline origin/release..origin/develop
+git tag --list 'vX.Y.Z-N'
+```
 
-- source branch: `release`
-- trigger: reviewed version tag
-- output: release image for downstream use
+Confirm `forte-ci` succeeded for the exact `release` SHA. GitHub branch protection and tag
+rulesets should require review and prevent force-push/tag deletion; these repository
+settings must be verified in GitHub because they are not versioned in this repository.
 
-### Temporary validation mode
+## 4. Create And Push The Release Tag
 
-- source branch: any reviewed branch
-- trigger: manual workflow dispatch with `BUILD_FROM_BRANCH=true`
-- output: temporary validation tag
+```bash
+git switch release
+git tag -a vX.Y.Z-N -m "Release vX.Y.Z-N"
+git show --no-patch --decorate vX.Y.Z-N
+git push origin vX.Y.Z-N
+```
 
-Temporary validation tags are useful for testing, but they are not trusted release inputs for secure deployment.
+The workflow independently rejects malformed/lightweight tags and tags that do not point to
+the current `origin/release` head.
 
-## Downstream Consumption Rule
+## 5. Workflow Publication
 
-- `secure-docker-blueprint` should consume reviewed version tags or, preferably, digests.
-- Downstream secure deployment must not depend on `latest`.
-- If the workflow continues to publish `latest`, treat it as convenience only, not as the secure source of truth.
+For each architecture, the workflow:
 
-## Required Release Record
+1. checks out the validated tag
+2. builds one local image
+3. runtime-tests that exact image
+4. scans that exact image with Trivy (currently report-only)
+5. generates a CycloneDX SBOM
+6. pushes the exact tested image under a unique workflow staging tag
+7. records the staging registry digest
 
-Every release should record:
+After both architecture jobs succeed, the finalizer verifies both staging digests, refuses
+to overwrite existing public version tags, creates the final AMD64 and ARM64 tags, updates
+the convenience `latest` tag to AMD64, creates provenance attestations for the final
+digests, and uploads `release-record.json`. If either architecture job fails, no public
+version tag or `latest` update occurs. GHCR tag creation itself is not transactional; if
+the finalizer fails between tag operations, the release is incomplete and all resulting
+tags must be inspected before a new build-number release is prepared.
 
-- version tag
-- `release` branch commit SHA
-- upstream source commit or tag
-- fork-only commits included
-- GHCR image reference
-- GHCR digest for amd64
-- GHCR digest for arm64, if published separately
-- release gates run
-- manual smoke checks completed
+## 6. Release Record And Downstream Handoff
 
-## Rollback Rule
+Record:
 
-Rollback should point to the previous reviewed version tag or digest, not to `latest`.
+- release tag and exact source SHA
+- upstream base and all accepted upstream ledger entries
+- fork-only commits/adaptations
+- AMD64 image reference and registry digest
+- ARM64 image reference and registry digest
+- workflow run URL/ID
+- SBOM artifacts and provenance attestation status
+- validation commands and known accepted risks
+- previous reviewed rollback tag/digest
 
-## Minimum Release Gates
+`secure-docker-blueprint` is a separate repository. It receives a reviewed architecture
+specific digest and release metadata; it does not consume `latest`.
 
-Before the tag is created:
+## Failure And Rollback Rules
 
-- reviewed diff understood
-- no unexplained fork-only app-source drift
-- `yarn type-check:ci --force`
-- relevant tests
-- build path understood
-- image destination confirmed as fork GHCR
-- no open question about whether downstream should consume the output
+- If tag validation fails, fix branch/tag preparation; do not bypass the workflow check.
+- If a build fails after tag push, keep the immutable Git tag as failed release evidence and
+  create a new build-number tag after the fix.
+- Never delete/reuse a published version tag or overwrite its GHCR tag.
+- If only one architecture published, mark the release incomplete and do not hand it off.
+- Roll back downstream to a previously recorded digest, never to `latest`.

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -28,6 +28,9 @@ Focus on these areas first:
 - inspect auth and mail logging changes
 - inspect cron and webhook auth changes
 - inspect dependency and lockfile changes
+- reconcile every observed upstream commit in `UPSTREAM_REVIEW_LEDGER.md`
+- confirm the current intake did not squash multiple upstream commits into one local commit
+- confirm partial upstream intake lists exact retained and omitted behavior
 
 ## Minimum Checks Before A Release Tag
 
@@ -36,6 +39,10 @@ Focus on these areas first:
 - `git diff --check`
 - manual review of release workflow and image destination
 - manual smoke check plan for the resulting image
+- lifecycle/install source-clean check
+- non-publishing AMD64 and ARM64 workflow validation
+- exact release-tag-to-`origin/release` identity check
+- architecture-specific digest, SBOM, and provenance capture plan
 
 ## Release Blocking Conditions
 
@@ -47,6 +54,10 @@ Do not approve a release image for downstream use if any of these are true:
 - only `latest` is available and the digest is not recorded
 - a security-sensitive change is present without review
 - a known secret-handling issue is accepted without documentation
+- the release tag does not point exactly to the reviewed `origin/release` head
+- the published digest is not the digest of the tested image
+- either architecture or the release finalizer failed
+- generated tracked files differ after install/lifecycle scripts
 
 ## Incident-Oriented Checks
 

--- a/UPSTREAM_REVIEW_LEDGER.md
+++ b/UPSTREAM_REVIEW_LEDGER.md
@@ -1,0 +1,124 @@
+# Upstream Review Ledger
+
+This ledger is the public commit-level record of what this fork did with upstream changes.
+It complements the chronological [.ai/sync-log.md](.ai/sync-log.md): the sync log explains
+review rounds, while this file gives every reviewed upstream commit a durable disposition.
+
+- Last reconciled: **2026-08-10**
+- Upstream range: `46eb533dbd..176037d0af` (50 commits)
+- Current integrated count: **8 full upstream patches**
+- Prepared but not integrated: **1**
+- Not integrated: **41**
+
+## Status Vocabulary
+
+| Status | Meaning |
+| --- | --- |
+| `integrated-full` | The complete upstream patch is present as its own local commit. |
+| `integrated-squashed` | The complete upstream patch is present, but historical local packaging combined it with other patches. This status is historical only and must not be created again. |
+| `already-covered` | Equivalent behavior existed independently; evidence must identify the local implementation. |
+| `partial` | Only identified parts were accepted. Exact files/hunks and the reason must be recorded. |
+| `prepared` | Reviewed and validated on a local review branch, but not integrated into `develop`. |
+| `candidate` | Relevant and awaiting a deliberate integration decision. |
+| `deferred` | Reviewed and intentionally postponed. |
+| `rejected` | Reviewed and intentionally excluded from this fork. |
+| `not-applicable` | The affected feature or code path is absent or disabled in this fork. |
+
+## Provenance Rules
+
+- One upstream commit becomes one local commit, applied with `git cherry-pick -x`.
+- Never squash multiple upstream commits into one local commit.
+- Keep required fork adaptations in a separate follow-up commit that names the upstream SHA.
+- If only part of an upstream patch is acceptable, do not describe it as a cherry-pick.
+  Record `partial`, the exact files or hunks retained, omitted behavior, and the reason.
+- A full upstream release merge may preserve upstream's original commits and merge topology;
+  it must not squash them into a synthetic aggregate commit.
+- Every status change records the review date, local commit when applicable, validation, and
+  release containing the change.
+
+## Integrated Upstream Commits
+
+Review date for this historical security intake: **2026-07-26**. Provenance and status were
+reconciled against current history on **2026-08-10**.
+
+| Upstream | Status | Local evidence | Notes |
+| --- | --- | --- | --- |
+| `fb0149453e` | `integrated-full` | `4d41b2c77d` | SECURITY.md wording; cherry-picked with provenance. |
+| `9104545a18` | `integrated-full` | `b8fb288779` | Password-update UX and translation; full patch. |
+| `0d164da8dd` | `integrated-full` | `91356f1650` | Password validation; initially rejected over legacy weak-password deletion risk, later accepted in full. The decision reversal should remain visible. |
+| `b97cd6203d` | `integrated-full` | `ec0dfcf9cc` | Dependency security audit; cherry-picked with provenance. |
+| `743f988d30` | `integrated-squashed` | `75c8f5c18f` | Full `shell-quote` 1.8.4 patch. Historical aggregate; do not repeat this packaging. |
+| `4026669e68` | `integrated-squashed` | `75c8f5c18f` | Full unauthenticated `/api/me` 401 patch. Historical aggregate. |
+| `ca03f007df` | `integrated-squashed` | `75c8f5c18f` | Full verified-phone lookup patch. Historical aggregate. |
+| `561cf889ab` | `integrated-squashed` | `75c8f5c18f` | Full Daily webhook BookingRepository patch. Historical aggregate. |
+
+The four patches represented by `75c8f5c18f` have aggregate file statistics matching the
+sum of their upstream patches. No partial hunk intake was found. Their provenance is weak
+because the local commit message does not contain the four upstream SHAs; this ledger is the
+durable corrective record.
+
+## Reviewed Upstream Commits Not Integrated
+
+Commits through `3894f37e14` were reviewed by **2026-07-26** and reconciled on
+**2026-08-10**. The six commits after that anchor (`ab0b9e1fb5..176037d0af`) were reviewed
+on **2026-08-10**. A later status change must record its own date in the decision text.
+
+| Upstream | Subject / area | Status | Decision |
+| --- | --- | --- | --- |
+| `a4a01a0fa8` | Remove attribute entrypoints | `deferred` | Cleanup/refactor; no security need. |
+| `180ede28f0` | System font fallback for non-Latin scripts | `deferred` | UI compatibility improvement. |
+| `717fed8f86` | Vitest patched-version update | `candidate` | Re-check advisory applicability before the next dependency round. |
+| `287cea3001` | `getQueryParam` typo | `deferred` | No runtime impact. |
+| `e003426580` | ProfilesRepository write service | `deferred` | Broad repository refactor. |
+| `ff184db553` | Arabic upload/download translation | `deferred` | Translation-only. |
+| `d1ad4ea8b2` | Persist cancellation-reason setting | `candidate` | Functional event-type fix; integrate if affected. |
+| `07a288bbd8` | Missing API-key tRPC route | `deferred` | Feature/API expansion not required by current fork scope. |
+| `c645c0cbf7` | Conferencing metadata null check | `candidate` | Defensive runtime fix; requires focused relevance review. |
+| `75c5eb8531` | Membership write service | `deferred` | Repository refactor. |
+| `ecfb05ba55` | Rethrow unexpected selected-calendar deletion errors | `candidate` | Error-handling correctness; requires API v2 review. |
+| `a216f6b785` | i18n typo | `deferred` | Copy-only. |
+| `642c38582e` | CLAUDE.md symlink casing | `not-applicable` | Fork owns `AGENTS.md`/`CLAUDE.md` guidance. |
+| `dcd0da831f` | Signup repository refactor | `deferred` | Auth-sensitive refactor; no demonstrated security requirement. |
+| `70a883b191` | CI cancellation retry | `not-applicable` | Upstream CI behavior is not used by fork CI. |
+| `4e529cbad1` | User-table infinite scroll | `deferred` | UI feature. |
+| `ebf696a991` | Remove console logging / tRPC typing | `candidate` | Logging and type-safety improvement; inspect for sensitive output impact. |
+| `1599dfd515` | Username suffix zero-padding | `deferred` | Functional polish. |
+| `7469444aea` | Confirmation dialog alignment | `deferred` | UI-only. |
+| `c0b13fb120` | Remove Discussions links | `deferred` | Documentation-only. |
+| `a46d5f8dd4` | Upstream Claude rule frontmatter | `not-applicable` | Fork-owned AI instructions take precedence. |
+| `051ae77279` | Remove obsolete TypeScript comment | `deferred` | Cleanup-only. |
+| `62317bd4e1` | Seat-payment booking fields and locale | `candidate` | Payment/booking correctness; requires focused review. |
+| `5d6d4d30cc` | App-category metadata typing | `deferred` | Refactor/type-safety improvement. |
+| `53e32a5bba` | Return 404 for missing booking | `candidate` | API behavior correction; requires compatibility review. |
+| `8f89c082e8` | Hebrew duration spacing | `deferred` | Translation-only. |
+| `032962f577` | Markdown headings in event descriptions | `deferred` | Rendering improvement; review sanitization before intake. |
+| `188aaa1857` | Cancellation ICS `METHOD:CANCEL` | `candidate` | Email/calendar interoperability fix. |
+| `f3284f581f` | Windows Prisma troubleshooting | `deferred` | Upstream setup documentation. |
+| `ca90ca2c94` | App-store credential repository refactor | `deferred` | Credential-sensitive refactor; no demonstrated required fix. |
+| `0968bcef01` | Synchronize Cal.diy `iCalUID` events | `candidate` | Calendar synchronization correctness. |
+| `bb7c87cae1` | Instance URL in push-test notification | `candidate` | Self-host correctness. |
+| `009f91d163` | Skip null user-field responses | `candidate` | Booking parser robustness. |
+| `761b780aa2` | Refund all paid seat payments on cancellation | `candidate` | Payment correctness; high-impact and requires dedicated tests. |
+| `f004349273` | Rename location helper | `deferred` | Refactor-only. |
+| `3894f37e14` | Hebrew duration spacing | `deferred` | Translation-only. |
+| `ab0b9e1fb5` | Remove obsolete Booker lint suppression | `deferred` | No runtime impact. |
+| `038381aeca` | Trim forwarded IP whitespace / banlist bypass | `prepared` | Security fix isolated and validated locally; not yet on `develop`. |
+| `8418db70c7` | Add Clara app | `rejected` | New external integration is outside the hardened fork scope. |
+| `5e3fe3cbe6` | Stable phone-input country fallback | `candidate` | Booking UX correctness; lower priority. |
+| `b2c28a23ab` | Language update functionality | `deferred` | UI/profile behavior; no security requirement. |
+| `176037d0af` | Preserve custom email reply-to | `candidate` | Relevant mail behavior fix; requires focused review. |
+
+## Updating This Ledger
+
+For every upstream review:
+
+1. append every newly observed upstream commit
+2. assign a status and review date in this ledger
+3. link the local commit when integrated
+4. record partial intake precisely rather than implying full inclusion
+5. update [FORK_STATUS.md](FORK_STATUS.md) and [.ai/sync-log.md](.ai/sync-log.md)
+6. record the first release tag and image digest containing each integrated change
+
+Git patch equivalence is useful evidence but not sufficient by itself: historical squashes,
+conflict resolutions, and fork adaptations can defeat `git cherry`. Reconcile this ledger
+against both patch IDs and documented local commits.

--- a/UPSTREAM_SYNC.md
+++ b/UPSTREAM_SYNC.md
@@ -34,7 +34,7 @@ The intended flow is:
 1. fetch upstream
 2. compare upstream to local `main`
 3. update `main` to the desired upstream state
-4. merge or rebase that reviewed state into `develop`
+4. integrate reviewed commits into `develop` using one of the explicit modes below
 5. run release gates on `develop`
 6. promote to `release` only after review
 
@@ -96,6 +96,25 @@ git log --oneline --no-merges develop..origin/main \
 - Keep `develop` as the branch where conflicts are reviewed and resolved.
 - Keep `release` free of surprise integration work.
 
+## Integration Modes
+
+### Selective intake (default)
+
+- Cherry-pick exactly one upstream commit at a time with `git cherry-pick -x <sha>`.
+- Never squash multiple upstream commits into one local commit.
+- Run focused validation and update [UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md)
+  before moving to the next commit.
+- Put fork-specific adaptations in a separate follow-up commit.
+- For partial intake, apply only the reviewed patch and record exact retained/omitted scope
+  as `partial`; do not claim a full cherry-pick.
+
+### Full release-base sync (exception)
+
+- Pin the exact upstream release tag first.
+- Preserve upstream commits and merge topology; never squash the release range.
+- Review the complete range and all fork-owned conflict resolutions.
+- Record every upstream commit and every conflict decision in the ledger and sync log.
+
 ## Conflict Rules
 
 - Fork-owned files need manual review every sync.
@@ -107,7 +126,7 @@ git log --oneline --no-merges develop..origin/main \
 After `main` reflects the chosen upstream state:
 
 1. compare `main...develop`
-2. merge or rebase `main` into `develop`
+2. choose selective intake or a documented full release-base merge
 3. inspect fork-owned drift
 4. run release gates
 5. record what changed
@@ -122,6 +141,7 @@ git log --oneline --decorate main..develop
 ## What Must Be Recorded For Each Sync
 
 - upstream commit or tag reviewed
+- one ledger row for every reviewed upstream commit, including deferred/rejected changes
 - resulting `main` commit
 - resulting `develop` commit
 - fork-only files kept intentionally divergent
@@ -136,3 +156,4 @@ git log --oneline --decorate main..develop
 - do not publish a release image from an unreviewed sync
 - do not assume docs and image references remain correct after upstream changes
 - do not collapse fork-only workflow/docs changes into app-source review without calling them out
+- do not combine multiple upstream commits into a local aggregate commit

--- a/apps/api/v2/Dockerfile
+++ b/apps/api/v2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS build
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS build
 
 ARG DATABASE_DIRECT_URL
 ARG DATABASE_URL
@@ -16,7 +16,7 @@ ENV USE_POOL="true"
 
 COPY . .
 
-RUN yarn install
+RUN yarn install --immutable
 RUN yarn workspace @calcom/api-v2 run generate-schemas
 RUN yarn workspace @calcom/api-v2 run build:docker
 RUN yarn workspace @calcom/api-v2 run build

--- a/apps/api/v2/Dockerfile
+++ b/apps/api/v2/Dockerfile
@@ -21,6 +21,11 @@ RUN yarn workspace @calcom/api-v2 run generate-schemas
 RUN yarn workspace @calcom/api-v2 run build:docker
 RUN yarn workspace @calcom/api-v2 run build
 
+USER node
+
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
+  CMD node -e "fetch('http://localhost:' + (process.env.API_PORT || '5555') + '/health').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
 
 CMD [ "yarn", "workspace", "@calcom/api-v2", "start:prod"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ networks:
 services:
   database:
     container_name: database
-    image: postgres
+    image: postgres:16-bookworm@sha256:64154d0babcb1741988719e703419af0382b19953706149f9872fbd0f438efa8
     restart: always
     volumes:
       - database-data:/var/lib/postgresql
@@ -25,7 +25,7 @@ services:
 
   redis:
     container_name: redis
-    image: redis:latest
+    image: redis:7-bookworm@sha256:e9b2e45ecd47fbb69b877cf8d045d5cccaaaed52524b6e098b4abe8212994f73
     restart: always
     volumes:
       - redis-data:/data
@@ -35,7 +35,8 @@ services:
       - "${REDIS_PORT:-6379}:6379"
 
   calcom:
-    image: calcom.docker.scarf.sh/calcom/cal.diy
+    # Override CALDIY_IMAGE with a reviewed GHCR digest for deployment.
+    image: ${CALDIY_IMAGE:-ghcr.io/rubennati/cal.diy:v6.2.0-4}
     build:
       context: .
       dockerfile: Dockerfile
@@ -122,7 +123,7 @@ services:
 
   # Optional use of Prisma Studio. In production, comment out or remove the section below to prevent unwanted access to your database.
   studio:
-    image: calcom.docker.scarf.sh/calcom/cal.diy
+    image: ${CALDIY_IMAGE:-ghcr.io/rubennati/cal.diy:v6.2.0-4}
     restart: always
     networks:
       - stack
@@ -141,4 +142,3 @@ services:
       - prisma
       - studio
 # END SECTION: Optional use of Prisma Studio.
-


### PR DESCRIPTION
## Summary

- add a complete 50-commit upstream review ledger with dated dispositions and explicit provenance
- prohibit new aggregate upstream cherry-picks and document the historical exception
- pin GitHub Actions and Docker base images to immutable revisions
- enforce immutable installs and fail CI when lifecycle generation changes tracked files
- run both runtime images as a non-root user and add the API v2 health check
- make manual Docker workflow dispatch validation-only
- build, runtime-test, scan, and publish the exact same architecture image
- delay public release tags and `latest` until both architecture jobs succeed
- capture GHCR digests, CycloneDX SBOMs, provenance attestations, and a release record
- document the one-time release-branch ancestry reconciliation required before the next promotion

## Why

The previous release path could publish from overly broad triggers, rebuild after validation,
report a non-registry digest, move `latest` before the complete architecture result, and did
not maintain an exhaustive upstream decision record. The release branch also contains
historical release-only ancestry that prevents the intended fast-forward promotion model.

## Impact

Manual workflow runs can no longer publish. Tag publication is restricted to annotated
`vX.Y.Z-N` tags pointing at the reviewed release source. Downstream deployment remains a
separate responsibility and must consume reviewed tags or, preferably, recorded architecture
digests.

No application source code is changed. The separately prepared IP-banlist security patch is
not included in this PR.

## Validation

- `YARN_ENABLE_SCRIPTS=false corepack yarn install --immutable`
- `corepack yarn type-check:ci --force` (10/10 tasks)
- actionlint 1.7.12
- YAML parse for changed workflows/actions
- `docker compose config --no-interpolate --quiet`
- `git diff --check`
- local Markdown link verification
- upstream ledger coverage: 50/50 commits
- GitHub `forte-ci` (install cleanliness, fork guard, typecheck, Biome): passed
- GitHub CodeQL: passed
- GitHub Trivy filesystem and code-scanning checks: passed

## Follow-up gates

- verify branch/tag rulesets and GHCR package settings
- complete the separately reviewed, content-neutral release ancestry reconciliation before the next fast-forward promotion
- perform a non-publishing AMD64/ARM64 workflow run before any future release
