### PR TITLE
ci: update actions to node24 runtime

### DIFF
--- a/.github/workflows/forte-ci.yml
+++ b/.github/workflows/forte-ci.yml
@@ -21,10 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Enable corepack (yarn 4)
         run: corepack enable
       - name: Install (immutable)

--- a/.github/workflows/forte-codeql.yml
+++ b/.github/workflows/forte-codeql.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           languages: javascript-typescript

--- a/.github/workflows/forte-scorecard.yml
+++ b/.github/workflows/forte-scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
       - name: Run Scorecard

--- a/.github/workflows/forte-trivy.yml
+++ b/.github/workflows/forte-trivy.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -33,7 +33,7 @@ jobs:
       source_sha: ${{ steps.identity.outputs.source_sha }}
     steps:
       - name: Checkout requested source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout validated source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
@@ -151,7 +151,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout validated source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
@@ -188,7 +188,7 @@ jobs:
       digest: ${{ steps.image.outputs.digest }}
     steps:
       - name: Checkout validated release tag
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
@@ -227,7 +227,7 @@ jobs:
       digest: ${{ steps.image.outputs.digest }}
     steps:
       - name: Checkout validated release tag
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 


### PR DESCRIPTION
## Summary

- update active fork workflows from `actions/checkout` v4 to pinned v6.1.0
- update fork CI from `actions/setup-node` v4 to pinned v6.5.0
- explicitly disable setup-node package-manager caching

The application, Docker images, and CI build environment remain on Node.js 20. This change only moves the GitHub Actions JavaScript runtime from deprecated Node.js 20 to Node.js 24.

## Scope

- workflow metadata only
- no application or Dockerfile changes
- no release or image publication

## Validation

- `git diff --check`
- YAML parsed successfully with Ruby Psych
- action release tags and immutable SHAs verified against the official GitHub repositories
