### PR TITLE
fix(ci): prepare compose env for Docker validation

### DIFF
--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -78,6 +78,20 @@ runs:
         echo "image_ref=ghcr.io/rubennati/cal.diy:${IMAGE_TAG}${PLATFORM_SUFFIX}" >> "$GITHUB_OUTPUT"
         echo "sbom_path=$sbom_path" >> "$GITHUB_OUTPUT"
 
+    - name: Prepare Compose environment file
+      id: compose-env
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -e .env ]]; then
+          echo "created=false" >> "$GITHUB_OUTPUT"
+        else
+          # Compose validates service-level env_file references even when only the
+          # database service is selected. Runtime secrets are supplied separately.
+          : > .env
+          echo "created=true" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Start ephemeral database
       shell: bash
       run: |
@@ -226,4 +240,9 @@ runs:
       if: always()
       shell: bash
       run: |
-        docker compose down --volumes
+        cleanup_status=0
+        docker compose down --volumes || cleanup_status=$?
+        if [[ "${{ steps.compose-env.outputs.created }}" == "true" ]]; then
+          rm -f .env
+        fi
+        exit "$cleanup_status"


### PR DESCRIPTION
## Summary

Fix the validation-only Docker workflow failing before the build because Compose requires the service-level `.env` file to exist even when only `database` is selected.

## Behavior

- create an empty temporary `.env` only when none exists
- continue supplying ephemeral database values and runtime secrets through the workflow
- remove `.env` during `always()` cleanup only when the action created it
- preserve any pre-existing `.env`

## Evidence

Failed validation run: https://github.com/rubennati/cal.diy/actions/runs/31423812708

Both AMD64 and ARM64 failed with the same error:

```text
env file .../.env not found
```

All publish jobs were skipped and no image was published.

## Scope

- one fork-owned composite action
- no application, Dockerfile, Compose deployment, dependency, or release-state changes

## Validation

- YAML parsed successfully
- `git diff --check`
- exact end-to-end validation will be the manual `Release Docker` run on `develop` after merge
