### PR TITLE
fix(docker): include all workspaces for immutable install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,10 @@ ENV NEXT_PUBLIC_WEBAPP_URL=http://NEXT_PUBLIC_WEBAPP_URL_PLACEHOLDER \
 
 COPY package.json yarn.lock .yarnrc.yml playwright.config.ts turbo.json i18n.json ./
 COPY .yarn ./.yarn
-COPY apps/web ./apps/web
-COPY apps/api/v2 ./apps/api/v2
+# Yarn's immutable resolution needs every workspace manifest represented by the
+# root workspace patterns, even though only web/API sources are shipped later.
+COPY apps ./apps
+COPY example-apps ./example-apps
 COPY packages ./packages
 
 RUN yarn config set httpTimeout 1200000


### PR DESCRIPTION
## Summary

Make the Docker builder's workspace set consistent with the root Yarn workspace patterns before `yarn install --immutable`.

## Root cause

The builder copied only `apps/web`, `apps/api/v2`, and `packages`, while the root project declares workspaces under:

- `apps/*`
- `apps/api/*`
- `packages/*` and nested package groups
- `example-apps/*`

Yarn therefore treated omitted workspaces as removed and correctly rejected the immutable install with `YN0028`.

Failed validation run: https://github.com/rubennati/cal.diy/actions/runs/31424917540

## Fix

- copy all `apps` into the builder stage
- copy `example-apps` into the builder stage
- retain the existing complete `packages` copy
- keep `yarn install --immutable`

The final runtime stage remains unchanged and still receives only the previously selected built web/package tree.

## Scope

- one Dockerfile
- no lockfile, dependency, application behavior, workflow publication, or runtime-stage change

## Validation

- every root workspace pattern maps to a copied builder root
- `git diff --check`
- exact end-to-end validation will be the manual non-publishing Docker workflow after merge
