### PR TITLE
fix(docker): move Yarn runtime state to tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,8 @@ ARG NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
 ENV NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL \
   BUILT_NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL
 
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+  YARN_INSTALL_STATE_PATH=/tmp/cal-forte-install-state.gz
 
 # cal.forte hardened defaults — privacy-by-default; override via runtime env if ever needed.
 # No usage-telemetry flag here on purpose: the upstream telemetry module is deleted in this


### PR DESCRIPTION
## Summary
- redirect Yarn runtime install-state file to writable `/tmp`
- preserve the non-root runner and read-only application tree
- fix the runtime smoke-test failure seen in Release Docker run 31426434500

## Scope
- one runtime environment variable in `Dockerfile`
- no application-source, dependency, workflow, tag, or publish changes

## Validation
- `git diff --check`
- full Docker validation will run after merge with publishing disabled