### PR TITLE
fix(docker): persist Yarn runtime state config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,8 +107,7 @@ ARG NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
 ENV NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL \
   BUILT_NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL
 
-ENV NODE_ENV=production \
-  YARN_INSTALL_STATE_PATH=/tmp/cal-forte-install-state.gz
+ENV NODE_ENV=production
 
 # cal.forte hardened defaults — privacy-by-default; override via runtime env if ever needed.
 # No usage-telemetry flag here on purpose: the upstream telemetry module is deleted in this
@@ -120,7 +119,8 @@ ENV GOOGLE_ADS_ENABLED=0 \
 # Runtime URL replacement and Turbo/Next caches need these paths writable without granting
 # ownership of the complete application tree.
 RUN mkdir -p /calcom/.turbo \
-  && chown -R node:node /calcom/.turbo /calcom/apps/web/.next /calcom/apps/web/public
+  && chown -R node:node /calcom/.turbo /calcom/apps/web/.next /calcom/apps/web/public \
+  && yarn config set installStatePath /tmp/cal-forte-install-state.gz
 
 USER node
 


### PR DESCRIPTION
## Summary
- persist the writable Yarn install-state path in the final image configuration
- ensure nested Yarn processes launched through strict Turbo tasks use `/tmp`
- preserve the non-root runner and read-only application tree

## Evidence
Release Docker run 31428938739 proved that an environment-only setting is filtered before the workspace start task. Both architectures otherwise built and reached the runtime smoke test.

## Scope
- `Dockerfile` only
- no app-source, dependency, workflow, tag, or publish changes
- supersedes the environment-only implementation from PR #8