### PR TITLE
docs: record v6.2.0-5 release transparency

### DIFF
--- a/.ai/state.md
+++ b/.ai/state.md
@@ -14,32 +14,29 @@ steady-state divergence: [../FORK_DIVERGENCE.md](../FORK_DIVERGENCE.md).
 - this repo is **public** → never commit real/personal data (company, support address,
   personal logo); those belong in the private deployment
 
-## Status (as of 2026-08-10)
+## Status (as of 2026-08-11)
 
 **Identity:** `cal.forte` — hardened, review-gated fork of Cal.diy (MIT community edition).
 Upstream intake is selective and recorded commit-by-commit in
 [../UPSTREAM_REVIEW_LEDGER.md](../UPSTREAM_REVIEW_LEDGER.md).
 
 **Branches:** `main` = untouched upstream mirror · `develop` = integration/review ·
-`release` = reviewed source for the GHCR image (currently `f99367c3`).
+`release` = reviewed source for GHCR images. The latest published source is `201b016984`.
 
-**Latest release:** `v6.2.0-4` — `ghcr.io/rubennati/cal.diy:v6.2.0-4`,
-digest `sha256:9818a0be6404bbcf6b330847868d2673ded00b9786ecb6683f49e907cf77a1a8`
-(amd64; arm64 is published as a separate `-arm` tag, no merged multi-arch manifest).
-Contains: cal.forte branding, hardened defaults (ad-tracking off, plus the then-still-present
-`CALCOM_TELEMETRY_DISABLED=1`), next-auth 4.24.15, websocket-driver 0.7.5, and a slimmed
-image (Stage 1 + 2).
+**Latest release:** `v6.2.0-5` from `201b016984`:
+- AMD64: `ghcr.io/rubennati/cal.diy:v6.2.0-5@sha256:c2facc284b28e1eea76b6d82c02e680d20d648dc255ef7f74520dbf30d18b17e`
+- ARM64: `ghcr.io/rubennati/cal.diy:v6.2.0-5-arm@sha256:dffa387024a68b9b057b1bdf3342a21b699bb092da4f711932f129bd932faeae`
 
-**Unreleased on `develop`:** the upstream telemetry module and the
-`CALCOM_TELEMETRY_DISABLED` flag are **gone** (the flag gated nothing — see
-[../FORK_DIVERGENCE.md](../FORK_DIVERGENCE.md)). No runtime behaviour changes, but the Dockerfile did, so
-the next image differs from `v6.2.0-4`. `packages/lib` now type-checks in CI, and four
-orphaned rotted files were deleted.
+It contains the telemetry removal and guard, repaired `packages/lib` type-check coverage,
+the IP-banlist whitespace fix, non-root runtimes, immutable build inputs, and the hardened
+two-architecture release pipeline. Release Docker run `31435807941` produced SBOMs,
+provenance, and the authoritative release record. Downstream handoff is tracked in
+`secure-docker-blueprint` issue #30.
 
-**Release topology blocker:** `origin/release` ends at `f99367c3` with five historical
-release-only commits and is not an ancestor of `origin/develop`. Complete the one-time
-content-neutral ancestry reconciliation in [../RELEASE_PROCESS.md](../RELEASE_PROCESS.md)
-before the next fast-forward promotion; never force-push `release` to bypass it.
+**Release topology:** the one-time content-neutral ancestry reconciliation completed in
+`a4e2ff5dcd`; `develop` and `release` were source-identical at published SHA `201b016984`.
+Future promotions use the normal fast-forward process in
+[../RELEASE_PROCESS.md](../RELEASE_PROCESS.md).
 
 **Security posture:**
 - Security fixes are taken from upstream by default; validate they are *real* fixes
@@ -70,11 +67,11 @@ already removed upstream-side. Details: [branding.md](branding.md).
 - Tracks cal.com **6.2.0** (`apps/web/package.json` on `main` and `develop`).
 - Fork divergence point (merge-base `develop`↔`origin/main`): **`46eb533d`**.
 - Mirror `origin/main` last reviewed through `176037d0af`: 50 commits past base, still the
-  6.2.0 patch line. Eight complete upstream patches are integrated, one security fix is
-  prepared locally, and 41 are not integrated. Exact dispositions and historical aggregate
+  6.2.0 patch line. Nine complete upstream patches are integrated, none are prepared, and
+  41 are not integrated. Exact dispositions and historical aggregate
   provenance are in [../UPSTREAM_REVIEW_LEDGER.md](../UPSTREAM_REVIEW_LEDGER.md).
 - ⚠️ The repo's `v6.2.0` tag points at a **fork** commit (`a39c99f5`), **not** the upstream
-  release. Fork release tags are `v6.2.0-1..-4`. Pin bases to the merge-base / real upstream tag.
+  release. Fork release tags are `v6.2.0-1..-5`. Pin bases to the merge-base / real upstream tag.
 
 ## Knowledge base map
 

--- a/.ai/sync-log.md
+++ b/.ai/sync-log.md
@@ -254,6 +254,47 @@ can drop it. Ad-tracking remains off by default.
 
 ---
 
+## 2026-08-11 — Release `v6.2.0-5` and downstream handoff
+
+**Context:** The reviewed `develop` state was promoted after local install/type-check gates
+and repeated non-publishing AMD64/ARM64 Docker validation. The release also completed the
+one-time historical ancestry reconciliation required for future fast-forward promotions.
+
+**Release source:** `201b016984fe13388ccdc6a82f2669e9719d3bcc`
+
+**Release preparation:**
+- PR #8 redirected Yarn runtime state to writable `/tmp`; a Docker gate showed that Turbo's
+  strict task environment filtered the environment-only setting.
+- PR #9 persisted `installStatePath` in the final image's Yarn configuration; both
+  architecture runtime tests then passed.
+- PR #10 linked the five historical release-only commits with a content-neutral `ours`
+  ancestry merge. Its file diff was empty; `release` then fast-forwarded to `develop`.
+
+**Checks:** `forte-ci`, CodeQL, Trivy, and Scorecard passed for the exact source SHA.
+Non-publishing Release Docker run
+[`31433538582`](https://github.com/rubennati/cal.diy/actions/runs/31433538582) passed source
+identity, runtime tests, image scans, and SBOM generation on AMD64 and ARM64.
+
+**Published artifacts:** Release Docker run
+[`31435807941`](https://github.com/rubennati/cal.diy/actions/runs/31435807941) validated the
+annotated `v6.2.0-5` tag, published both architecture images, finalized `latest` as
+convenience metadata, uploaded CycloneDX SBOMs and `release-record.json`, and pushed build
+provenance attestations.
+
+- AMD64: `ghcr.io/rubennati/cal.diy:v6.2.0-5@sha256:c2facc284b28e1eea76b6d82c02e680d20d648dc255ef7f74520dbf30d18b17e`
+- ARM64: `ghcr.io/rubennati/cal.diy:v6.2.0-5-arm@sha256:dffa387024a68b9b057b1bdf3342a21b699bb092da4f711932f129bd932faeae`
+
+**Downstream handoff:**
+[secure-docker-blueprint issue #30](https://github.com/rubennati/secure-docker-blueprint/issues/30)
+records the digest update and required non-root, secrets, migration, health, booking, SMTP,
+and rollback validation. `latest` is not a downstream trust input.
+
+**Documentation follow-up:** The historical release-only README conflicted with the new
+source-identical promotion model. The shared fork README is now branch-neutral for
+`develop` and `release`; `main` continues to carry the upstream README.
+
+---
+
 <!-- Template for the next entry:
 
 ## YYYY-MM-DD — <short title>

--- a/FORK_DIVERGENCE.md
+++ b/FORK_DIVERGENCE.md
@@ -15,14 +15,14 @@ audit, maintain, and trust.
 
 ## Current Basis
 
-Last reconciled: **2026-08-10**
+Last reconciled: **2026-08-11**
 
 | Item | Value |
 | --- | --- |
 | Upstream base | Cal.com 6.2.0 at merge-base `46eb533dbd` |
 | Upstream reviewed through | `176037d0af` on 2026-08-10 |
-| Fork baseline reviewed | `develop` at `090a11b141` |
-| Latest published fork release | `v6.2.0-4` |
+| Latest published fork baseline | `201b016984` |
+| Latest published fork release | `v6.2.0-5` |
 | Exact source comparison | [`main...develop`](https://github.com/rubennati/cal.diy/compare/main...develop) |
 
 `Released` below names the first fork release known to contain the change. `Unreleased`
@@ -35,8 +35,8 @@ material intent and behavior.
 | Fork divergence | Type | Reason and effect | Evidence | Release state |
 | --- | --- | --- | --- | --- |
 | `cal.forte` identity and fork-owned README | Modified | Clearly distinguishes the hardened fork from upstream and exposes branch, review, and image trust boundaries. | `6423cafece`, `5a38545dab` | Released by `v6.2.0-2`; status updates continue on `develop` |
-| Controlled `main` / `develop` / `release` model | Added | Separates the upstream mirror, reviewed integration, and image publication source. | `73a5313f2a`, process documents | Released by `v6.2.0-1`; hardened rules unreleased |
-| Public upstream decision ledger | Added | Gives every reviewed upstream commit a durable disposition and provenance record. | `679c4f058c`, `UPSTREAM_REVIEW_LEDGER.md` | Unreleased |
+| Controlled `main` / `develop` / `release` model | Added | Separates the upstream mirror, reviewed integration, and image publication source. | `73a5313f2a`, process documents | Released by `v6.2.0-1`; hardened rules by `v6.2.0-5` |
+| Public upstream decision ledger | Added | Gives every reviewed upstream commit a durable disposition and provenance record. | `679c4f058c`, `UPSTREAM_REVIEW_LEDGER.md` | Released by `v6.2.0-5` |
 | Fork-owned AI collaboration guidance | Added/modified | Replaces upstream team-process instructions with concise rules for this controlled fork. | `31b42d3fef`, `6e41b14ce8` | Introduced in `v6.2.0-1`; expanded by `v6.2.0-2` |
 | Hardened deployment environment template | Added | Documents secure defaults without committing deployment secrets or private branding. | `d057ef3915`, `config/cal.forte.env.example` | Released by `v6.2.0-3` |
 
@@ -44,12 +44,12 @@ material intent and behavior.
 
 | Fork divergence | Type | Reason and effect | Evidence | Release state |
 | --- | --- | --- | --- | --- |
-| Inert Jitsu usage-telemetry module and phantom opt-out removed | Removed | Eliminates dormant phone-home code and avoids documenting a flag that controlled nothing. A blocking guard prevents reintroduction. | `75a9df1812`, `scripts/fork-guard-telemetry.sh` | Unreleased |
+| Inert Jitsu usage-telemetry module and phantom opt-out removed | Removed | Eliminates dormant phone-home code and avoids documenting a flag that controlled nothing. A blocking guard prevents reintroduction. | `75a9df1812`, `scripts/fork-guard-telemetry.sh` | Released by `v6.2.0-5` |
 | Advertising integrations disabled by default in the image | Modified | Sets privacy-first runtime defaults for Google and LinkedIn advertising. | `d057ef3915`, root `Dockerfile` | Released by `v6.2.0-3` |
 | Fork security contact | Modified | Vulnerability reports are directed to the fork owner rather than upstream Cal.com. | `d7747a32d9`, `.well-known/security.txt` | Released by `v6.2.0-2` |
-| Fork security CI | Added | Runs fork-owned type checking, CodeQL, Trivy, Scorecard, telemetry guard, and dependency monitoring on review/release branches rather than executing the broad upstream CI estate. | `68d13f4d28`, `.github/workflows/forte-*` | Released by `v6.2.0-2`; latest hardening unreleased |
-| Explicit Trivy image policy | Added | Scans the exact runtime-tested image. Findings remain report-only while inherited runtime CVEs are reduced; accepted exceptions and the re-enable condition are documented rather than presented as a blocking gate. | `38e498f196`, `.trivyignore`, `IMAGE_BUILD.md` | Released by `v6.2.0-3`; latest pipeline hardening unreleased |
-| `packages/lib` type-check coverage repaired | Modified | Brings previously uncompiled library files into the TypeScript gate and removes code that had silently rotted outside CI. | `88e8f9e226` | Unreleased |
+| Fork security CI | Added | Runs fork-owned type checking, CodeQL, Trivy, Scorecard, telemetry guard, and dependency monitoring on review/release branches rather than executing the broad upstream CI estate. | `68d13f4d28`, `.github/workflows/forte-*` | Released by `v6.2.0-2`; latest hardening by `v6.2.0-5` |
+| Explicit Trivy image policy | Added | Scans the exact runtime-tested image. Findings remain report-only while inherited runtime CVEs are reduced; accepted exceptions and the re-enable condition are documented rather than presented as a blocking gate. | `38e498f196`, `.trivyignore`, `IMAGE_BUILD.md` | Released by `v6.2.0-3`; latest pipeline hardening by `v6.2.0-5` |
+| `packages/lib` type-check coverage repaired | Modified | Brings previously uncompiled library files into the TypeScript gate and removes code that had silently rotted outside CI. | `88e8f9e226` | Released by `v6.2.0-5` |
 
 Upstream-derived security patches are intentionally not listed as fork inventions. Their
 source and local evidence belong in
@@ -63,20 +63,20 @@ source and local evidence belong in
 | `cal.forte` image branding | Modified | Bakes the fork application name through explicit build arguments. | `4264193f84` | Released by `v6.2.0-3` |
 | URL-safe database-password guidance | Modified | Warns operators that URL-reserved characters break interpolated PostgreSQL URLs and recommends hexadecimal secrets. | `aa4f4bff79`, `docker-compose.yml` | Released by `v6.2.0-1` |
 | Runtime image slimming, stages 1 and 2 | Modified | Excludes tests/E2E assets and removes dev-only tooling while retaining runtime-required Turbo, Prisma, and seed tooling. | `b14e95dbea`, `78527ca3f5`, `08db6081bd` | Released by `v6.2.0-4` |
-| Immutable Docker and Action inputs | Modified | Pins base-image digests and third-party Action SHAs, uses immutable Yarn installs, and lets Dependabot propose deliberate updates. | `32aac7c9fa` | Unreleased |
-| Non-root web and API runtimes | Modified | Runs application processes as the built-in `node` user; only required Next.js/Turbo runtime paths remain writable. API v2 also gains a health check. | `6800e65e06` | Unreleased |
-| Fork image selected by Compose | Modified | Uses the fork GHCR image and supports `CALDIY_IMAGE` override so deployment can pin a reviewed digest. PostgreSQL and Redis are digest-pinned. | `32aac7c9fa`, `docker-compose.yml` | Unreleased |
+| Immutable Docker and Action inputs | Modified | Pins base-image digests and third-party Action SHAs, uses immutable Yarn installs, and lets Dependabot propose deliberate updates. | `32aac7c9fa` | Released by `v6.2.0-5` |
+| Non-root web and API runtimes | Modified | Runs application processes as the built-in `node` user; only required Next.js/Turbo runtime paths remain writable. API v2 also gains a health check. | `6800e65e06` | Released by `v6.2.0-5` |
+| Fork image selected by Compose | Modified | Uses the fork GHCR image and supports `CALDIY_IMAGE` override so deployment can pin a reviewed digest. PostgreSQL and Redis are digest-pinned. | `32aac7c9fa`, `docker-compose.yml` | Released by `v6.2.0-5` |
 
 ## Release And Supply-Chain Changes
 
 | Fork divergence | Type | Reason and effect | Evidence | Release state |
 | --- | --- | --- | --- | --- |
-| Validation-only manual Docker workflow | Modified | Manual dispatch can build, smoke-test, scan, and create SBOMs but cannot publish. | `74f8665e6a` | Unreleased |
-| Strict release identity | Added | Publication requires an annotated `vX.Y.Z-N` tag on the reviewed `release` source with a tree equal to `develop`. | `74f8665e6a` | Unreleased |
-| Build once, publish the tested image | Modified | Removes the previous post-validation rebuild; each architecture pushes the exact image that passed runtime and scan checks. | `74f8665e6a` | Unreleased |
-| Two-architecture finalization | Added | AMD64 and ARM64 publish first to unique staging references; public version tags and `latest` are finalized only after both jobs succeed. | `74f8665e6a` | Unreleased |
-| Registry evidence | Added | Captures GHCR digests, CycloneDX SBOMs, provenance attestations, workflow identity, and `release-record.json`. | `74f8665e6a` | Unreleased |
-| Secure downstream contract | Added | Requires `secure-docker-blueprint` to consume reviewed architecture tags or preferably digests, never `latest` as a trust anchor. | `73a5313f2a`, `74f8665e6a` | Contract released; latest enforcement unreleased |
+| Validation-only manual Docker workflow | Modified | Manual dispatch can build, smoke-test, scan, and create SBOMs but cannot publish. | `74f8665e6a` | Released by `v6.2.0-5` |
+| Strict release identity | Added | Publication requires an annotated `vX.Y.Z-N` tag on the reviewed `release` source with a tree equal to `develop`. | `74f8665e6a` | Released by `v6.2.0-5` |
+| Build once, publish the tested image | Modified | Removes the previous post-validation rebuild; each architecture pushes the exact image that passed runtime and scan checks. | `74f8665e6a` | Released by `v6.2.0-5` |
+| Two-architecture finalization | Added | AMD64 and ARM64 publish first to unique staging references; public version tags and `latest` are finalized only after both jobs succeed. | `74f8665e6a` | Released by `v6.2.0-5` |
+| Registry evidence | Added | Captures GHCR digests, CycloneDX SBOMs, provenance attestations, workflow identity, and `release-record.json`. | `74f8665e6a` | Released by `v6.2.0-5` |
+| Secure downstream contract | Added | Requires `secure-docker-blueprint` to consume reviewed architecture tags or preferably digests, never `latest` as a trust anchor. | `73a5313f2a`, `74f8665e6a` | Contract introduced earlier; latest enforcement released by `v6.2.0-5` |
 
 GHCR retagging is not transactional. A failed finalization is treated as an incomplete
 release and requires inspection before a new build-number tag is prepared.
@@ -88,9 +88,9 @@ release and requires inspection before a new build-number tag is prepared.
 | `.cursor/`, `.changeset/`, `.vscode/`, `SPEC-WORKFLOW.md` | Upstream editor, NPM-release, and team-process machinery is not used by this fork. | `d7747a32d9` | Released by `v6.2.0-2` |
 | Upstream team-culture and PR-process AI rules | They describe Cal.com's organization rather than safe engineering of this repository. Technical rules remain. | `b8c32d0aca`, `6e41b14ce8` | Released by `v6.2.0-2` |
 | Broad upstream GitHub workflow set | It targets Cal.com's infrastructure, secrets, release process, cron operation, and test estate. Fork-owned workflows replace the required gates. Removing these workflow files does not remove the corresponding application routes; production scheduling is a deployment responsibility. | fork baseline, fork workflows | Fork baseline |
-| `packages/lib/domainManager/` | Orphaned and broken Vercel/Cloudflare organization-domain automation with no importers. | `88e8f9e226` | Unreleased |
-| `packages/lib/formbricks.ts` duplicate | Orphaned duplicate of the live feedback path and incompatible with the installed API client. The active Formbricks integration remains. | `88e8f9e226` | Unreleased |
-| `packages/lib/telemetry.ts` and related flags | Inert telemetry code and its misleading controls are removed and guarded against return. | `75a9df1812`, fork guard | Unreleased |
+| `packages/lib/domainManager/` | Orphaned and broken Vercel/Cloudflare organization-domain automation with no importers. | `88e8f9e226` | Released by `v6.2.0-5` |
+| `packages/lib/formbricks.ts` duplicate | Orphaned duplicate of the live feedback path and incompatible with the installed API client. The active Formbricks integration remains. | `88e8f9e226` | Released by `v6.2.0-5` |
+| `packages/lib/telemetry.ts` and related flags | Inert telemetry code and its misleading controls are removed and guarded against return. | `75a9df1812`, fork guard | Released by `v6.2.0-5` |
 
 Removal does not automatically mean an upstream feature is unsupported. Each row states
 the actual removed scope; adjacent live integrations remain unless explicitly named.
@@ -101,7 +101,7 @@ the actual removed scope; adjacent live integrations remain unless explicitly na
 | --- | --- | --- | --- | --- |
 | Fork-owned `CODEOWNERS` | Modified | Removes Cal.com organization ownership assumptions and assigns review responsibility within this fork. | `a39c99f5e0` | Fork tag `v6.2.0` |
 | README and security-contact merge guards | Added | `.gitattributes` marks identity/security-contact files with `merge=ours` so reviewed syncs do not silently restore upstream content. Each clone must configure the documented merge driver. | `6423cafece`, `d7747a32d9` | Released by `v6.2.0-2` |
-| Robust Biome pre-commit handling | Modified | Allows staged sets containing only Biome-ignored generated/declaration paths without incorrectly failing because no files were processed. | `778b4200f7`, `lint-staged.config.mjs` | Unreleased |
+| Robust Biome pre-commit handling | Modified | Allows staged sets containing only Biome-ignored generated/declaration paths without incorrectly failing because no files were processed. | `778b4200f7`, `lint-staged.config.mjs` | Released by `v6.2.0-5` |
 | Public fork process documentation | Added | Defines branch ownership, upstream intake, divergence, security review, release evidence, image handling, and downstream responsibility as auditable contracts. | root `FORK_*`, `UPSTREAM_*`, `RELEASE_PROCESS.md`, `IMAGE_BUILD.md` | Introduced in `v6.2.0-1`; continuously maintained |
 
 ## Intentionally Retained Upstream Components

--- a/FORK_STATUS.md
+++ b/FORK_STATUS.md
@@ -9,7 +9,7 @@ deferred, and rejected decisions are recorded in
 
 ## Current Snapshot
 
-Last verified: **2026-08-10**
+Last verified: **2026-08-11**
 
 | Item | Current state |
 | --- | --- |
@@ -17,11 +17,12 @@ Last verified: **2026-08-10**
 | Upstream reviewed through | `176037d0af` on 2026-08-10 |
 | Latest review range | [`3894f37e14...176037d0af`](https://github.com/rubennati/cal.diy/compare/3894f37e14...176037d0af) (6 commits) |
 | Integrated upstream base | [`46eb533dbd`](https://github.com/rubennati/cal.diy/commit/46eb533dbd20b74686efa520684e662c0f21051c) (Cal.com 6.2.0 base) |
-| Reviewed `develop` content baseline | [`99f4021d29`](https://github.com/rubennati/cal.diy/commit/99f4021d2921279b74e1ae4c902e370a26966c76) (before the IP-banlist integration) |
-| Reviewed release source | `release` at [`f99367c3a7`](https://github.com/rubennati/cal.diy/commit/f99367c3a75a0b69b59a058caf5e2114c5c0fb7d) |
-| Latest published release | [`v6.2.0-4`](https://github.com/rubennati/cal.diy/tree/v6.2.0-4) |
-| Published image | `ghcr.io/rubennati/cal.diy:v6.2.0-4` |
-| AMD64 digest | `sha256:9818a0be6404bbcf6b330847868d2673ded00b9786ecb6683f49e907cf77a1a8` |
+| Latest published source baseline | [`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe13388ccdc6a82f2669e9719d3bcc) |
+| Reviewed publication branch | [`release`](https://github.com/rubennati/cal.diy/tree/release) |
+| Latest published release | [`v6.2.0-5`](https://github.com/rubennati/cal.diy/tree/v6.2.0-5) |
+| Published AMD64 image | `ghcr.io/rubennati/cal.diy:v6.2.0-5` |
+| AMD64 digest | `sha256:c2facc284b28e1eea76b6d82c02e680d20d648dc255ef7f74520dbf30d18b17e` |
+| ARM64 digest | `sha256:dffa387024a68b9b057b1bdf3342a21b699bb092da4f711932f129bd932faeae` |
 
 The repository is selectively maintained. **Reviewed through** means that upstream commits
 through the stated point were assessed; it does not mean that every upstream commit was
@@ -48,7 +49,7 @@ full sync, and an integration does not imply that an image was published.
 
 | Upstream commit | Area | Review result |
 | --- | --- | --- |
-| `038381aeca` | IP parsing / banlist enforcement | **Integrated in full on 2026-08-10 as `29d686fa67`.** Trims forwarded-header whitespace to prevent an IP-banlist bypass. Not yet released. |
+| `038381aeca` | IP parsing / banlist enforcement | **Integrated in full on 2026-08-10 as `29d686fa67` and released in `v6.2.0-5`.** Trims forwarded-header whitespace to prevent an IP-banlist bypass. |
 | `176037d0af` | Email reply-to handling | Relevant functional fix; candidate for selective integration. |
 | `5e3fe3cbe6` | Booking phone input | Useful fallback fix; lower priority. |
 | `b2c28a23ab` | Language settings | Functional UI fix; deferred pending need. |
@@ -63,6 +64,9 @@ retain their recorded candidate, deferred, or rejected status.
 - `main` is the upstream-near mirror.
 - `develop` is the reviewed integration branch.
 - `release` is the reviewed source for release tags and GHCR images.
+- The historical release-only commits were reconciled as content-neutral ancestry in
+  [`a4e2ff5dcd`](https://github.com/rubennati/cal.diy/commit/a4e2ff5dcd4b81c4a7731b575058892651925c73);
+  release promotion is now a normal source-identical fast-forward.
 - The merge-base between `develop` and the reviewed upstream line is `46eb533dbd`.
 - Security fixes after that base are selectively cherry-picked; they are not evidence of a
   full upstream merge.
@@ -76,14 +80,16 @@ The exact current source difference can be inspected with the
 
 | Evidence | Value |
 | --- | --- |
-| Release tag | [`v6.2.0-4`](https://github.com/rubennati/cal.diy/tree/v6.2.0-4) |
+| Release tag | [`v6.2.0-5`](https://github.com/rubennati/cal.diy/tree/v6.2.0-5) |
 | Source branch | `release` |
-| Source commit | [`f99367c3a7`](https://github.com/rubennati/cal.diy/commit/f99367c3a75a0b69b59a058caf5e2114c5c0fb7d) |
-| Promoted `develop` commit | [`8b4a9cd8`](https://github.com/rubennati/cal.diy/commit/8b4a9cd8) |
-| AMD64 image | `ghcr.io/rubennati/cal.diy:v6.2.0-4` |
-| ARM64 image | `ghcr.io/rubennati/cal.diy:v6.2.0-4-arm` |
-| AMD64 digest | `sha256:9818a0be6404bbcf6b330847868d2673ded00b9786ecb6683f49e907cf77a1a8` |
-| Release workflow run | [`30223216533`](https://github.com/rubennati/cal.diy/actions/runs/30223216533) |
+| Source commit | [`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe13388ccdc6a82f2669e9719d3bcc) |
+| Promoted `develop` commit | [`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe13388ccdc6a82f2669e9719d3bcc) |
+| AMD64 image | `ghcr.io/rubennati/cal.diy:v6.2.0-5` |
+| ARM64 image | `ghcr.io/rubennati/cal.diy:v6.2.0-5-arm` |
+| AMD64 digest | `sha256:c2facc284b28e1eea76b6d82c02e680d20d648dc255ef7f74520dbf30d18b17e` |
+| ARM64 digest | `sha256:dffa387024a68b9b057b1bdf3342a21b699bb092da4f711932f129bd932faeae` |
+| Release workflow run | [`31435807941`](https://github.com/rubennati/cal.diy/actions/runs/31435807941) |
+| Downstream handoff | [secure-docker-blueprint issue #30](https://github.com/rubennati/secure-docker-blueprint/issues/30) |
 
 Downstream deployments must use a reviewed version tag or, preferably, a recorded digest.
 They must not treat `latest` as a secure deployment target. The complete artifact rules are
@@ -91,15 +97,10 @@ defined in [CALDIY_RELEASE_CONTRACT.md](CALDIY_RELEASE_CONTRACT.md).
 
 ## Known Limitations
 
-- `origin/release` has five historical release-only commits and is not yet an ancestor of
-  `origin/develop`; the one-time, content-neutral ancestry reconciliation in
-  [RELEASE_PROCESS.md](RELEASE_PROCESS.md) is required before the next fast-forward release.
 - `type-check:ci` does not cover every workspace package; see
   [.ai/quality-gates.md](.ai/quality-gates.md).
 - The Trivy image scan is currently report-only while inherited runtime-image findings are
   reduced; see [.ai/slimming-runtime-plan.md](.ai/slimming-runtime-plan.md).
-- The IP-banlist fix is integrated on `develop` but is not included in the latest published
-  release image until the next reviewed release promotion completes.
 - ARM64 is published under a separate `-arm` tag rather than a combined multi-architecture
   manifest.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!IMPORTANT]
 > **cal.forte — a hardened, controlled fork of Cal.diy. This is not upstream.**
-> You are on the `develop` (integration / review) branch — it diverges from upstream and
-> is **not a deployment target**. Deployable images come only from the `release` branch.
+> Changes are reviewed on `develop`; deployable images come only from reviewed tags on
+> `release`. Use a versioned, architecture-specific digest — never `latest` as a trust anchor.
 
 # cal.forte
 
@@ -15,18 +15,37 @@ compromise; every change here is deliberate and documented.
 **Fork changes:** Security defaults, telemetry, CI, container runtime, and release handling
 intentionally differ from Cal.diy. [See the public divergence register →](FORK_DIVERGENCE.md)
 
+**Latest release:** [`v6.2.0-5`](https://github.com/rubennati/cal.diy/tree/v6.2.0-5)
+from [`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe13388ccdc6a82f2669e9719d3bcc).
+[Full release evidence →](FORK_STATUS.md#latest-release-evidence)
+
 ## Branch model
 
 | Branch    | Purpose                                   | Deploy?           |
 |-----------|-------------------------------------------|-------------------|
 | `main`    | Untouched upstream mirror                 | no                |
-| `develop` | Fork integration & review (this branch)   | no                |
+| `develop` | Fork integration and review               | no                |
 | `release` | Reviewed source for the GHCR Docker image | tag / digest only |
 
 - Image: `ghcr.io/rubennati/cal.diy` — consume a **reviewed tag/digest**, never `latest`
-  (latest release recorded in [.ai/sync-log.md](.ai/sync-log.md)).
+  (latest release recorded in [FORK_STATUS.md](FORK_STATUS.md)).
 - Downstream deployment: [`secure-docker-blueprint`](https://github.com/rubennati/secure-docker-blueprint/tree/main/apps/caldiy).
-- Exact diff vs upstream: **https://github.com/rubennati/cal.diy/compare/main...develop**
+- Exact reviewed diff vs upstream: **https://github.com/rubennati/cal.diy/compare/main...develop**
+- Exact release diff vs upstream: **https://github.com/rubennati/cal.diy/compare/main...release**
+
+## Releases
+
+The latest published image was built from `release` at
+[`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe13388ccdc6a82f2669e9719d3bcc):
+
+- AMD64: `ghcr.io/rubennati/cal.diy:v6.2.0-5@sha256:c2facc284b28e1eea76b6d82c02e680d20d648dc255ef7f74520dbf30d18b17e`
+- ARM64: `ghcr.io/rubennati/cal.diy:v6.2.0-5-arm@sha256:dffa387024a68b9b057b1bdf3342a21b699bb092da4f711932f129bd932faeae`
+- Evidence: [Release Docker run 31435807941](https://github.com/rubennati/cal.diy/actions/runs/31435807941)
+- Downstream handoff: [secure-docker-blueprint issue #30](https://github.com/rubennati/secure-docker-blueprint/issues/30)
+
+Tags are architecture-specific; there is currently no combined multi-architecture manifest.
+See [FORK_STATUS.md](FORK_STATUS.md) for the maintenance snapshot and
+[CALDIY_RELEASE_CONTRACT.md](CALDIY_RELEASE_CONTRACT.md) for the downstream trust contract.
 
 ## 📚 Documentation & knowledge base
 

--- a/UPSTREAM_REVIEW_LEDGER.md
+++ b/UPSTREAM_REVIEW_LEDGER.md
@@ -51,7 +51,7 @@ reconciled against current history on **2026-08-10**.
 | `4026669e68` | `integrated-squashed` | `75c8f5c18f` | Full unauthenticated `/api/me` 401 patch. Historical aggregate. |
 | `ca03f007df` | `integrated-squashed` | `75c8f5c18f` | Full verified-phone lookup patch. Historical aggregate. |
 | `561cf889ab` | `integrated-squashed` | `75c8f5c18f` | Full Daily webhook BookingRepository patch. Historical aggregate. |
-| `038381aeca` | `integrated-full` | `29d686fa67` | Forwarded-IP whitespace / banlist-bypass fix; cherry-picked with `-x` on 2026-08-10. Fork-only formatting follow-up: `2ea6ff49b0`. Targeted tests passed (23/23) and filtered `@calcom/lib` type-check passed. Not yet released. |
+| `038381aeca` | `integrated-full` | `29d686fa67` | Forwarded-IP whitespace / banlist-bypass fix; cherry-picked with `-x` on 2026-08-10. Fork-only formatting follow-up: `2ea6ff49b0`. Targeted tests passed (23/23) and filtered `@calcom/lib` type-check passed. First released in `v6.2.0-5`. |
 
 The four patches represented by `75c8f5c18f` have aggregate file statistics matching the
 sum of their upstream patches. No partial hunk intake was found. Their provenance is weak


### PR DESCRIPTION
## Summary

- make the shared fork README branch-neutral for `develop` and `release`
- record the `v6.2.0-5` source commit, architecture-specific image digests, workflow evidence, and downstream handoff
- update fork status, divergence, upstream ledger, and internal AI state after the completed release and ancestry reconciliation

## Why

`develop` and `release` now share a source-identical promotion model, so a release-only README would become stale or require branch-specific documentation drift. This keeps one truthful README while preserving the immutable image source SHA and release evidence.

## Scope

Documentation only. No application, Dockerfile, Docker workflow, tag, or image changes.

## Validation

- `git diff --check`
- verified tag `v6.2.0-5` points to `201b016984fe13388ccdc6a82f2669e9719d3bcc`
- verified the changed-file set contains only six documentation/state files