### PR TITLE
ci: scope telemetry guard to executable surfaces

### DIFF
--- a/.github/workflows/forte-ci.yml
+++ b/.github/workflows/forte-ci.yml
@@ -43,6 +43,10 @@ jobs:
         # Blocking on purpose: this is the class of regression an upstream sync
         # re-introduces silently. See .ai/divergence.md.
         run: bash scripts/fork-guard-telemetry.sh
+      - name: Fork guard — self-test
+        # A guard is only worth blocking on if it still fires. Asserts both directions:
+        # documentation may name the removed indicators, executable surfaces may not.
+        run: bash scripts/fork-guard-telemetry.test.sh
       - name: Type check
         run: yarn type-check:ci --force
       - name: Lint (Biome)

--- a/FORK_IMPLEMENTATION_LEDGER.md
+++ b/FORK_IMPLEMENTATION_LEDGER.md
@@ -1098,6 +1098,55 @@ commit. See §11's note on the 2026-08-10 round.
 
 ---
 
+### FIL-0013 · Scope the telemetry guard to executable surfaces
+
+| Field | Value |
+| --- | --- |
+| Status | merged-not-released |
+| Type | `MAINTENANCE` / `SECURITY_GUARD_CORRECTION` |
+| GitHub issue | n/a |
+| PR | `BACKFILL_REQUIRED` — to be filled when this branch is opened as a PR |
+| Local commit(s) | `BACKFILL_REQUIRED` — this entry ships in the same commit it describes |
+| Released in | not yet released |
+| Implementation relationship | `CAL_FORTE_NATIVE` |
+| Source usage | `NONE` |
+| Licence disposition | `PERMISSIVE_COMPATIBLE` |
+
+**Problem / desired outcome.** The guard added with the telemetry removal (`75a9df1812`) searched
+every tracked file except `.ai/`, `README.md`, the workflow and itself. Once the governance and
+audit records landed on `develop`, the guard began failing on documentation that merely *named*
+the removed indicators — `FORK_IMPLEMENTATION_LEDGER.md`, `docs/EXTERNAL_FORK_INTAKE.md` and
+`docs/EXTERNAL_FORK_INTAKE_EVIDENCE.md`. This is a false-positive scope defect, not a
+vulnerability: the protected invariant was never breached, and no telemetry behaviour returned.
+
+**Implementation summary.** Exclusions are now by file semantics rather than by directory:
+`*.md` and `*.mdx` are out of scope, everything else is in. The blanket `.ai/` and
+`forte-ci.yml` exemptions are removed, so a non-Markdown file in either location is now scanned
+for the first time. The guard itself remains the one unavoidable exception. The protected
+indicators, the blocking CI step and the deletion of `packages/lib/telemetry.ts` are unchanged.
+
+| Dimension | Value |
+| --- | --- |
+| Security impact | Invariant preserved; scan scope is net wider on executable surfaces |
+| Attack-surface impact | Unchanged — no product code touched |
+| Compatibility impact | None |
+
+**Scope deliberately given up.** The guard previously failed if a hardening document
+re-advertised `CALCOM_TELEMETRY_DISABLED` as a live control. A fixed-string search cannot tell
+that apart from a record that the flag was removed, which is precisely why it fired on the audit
+set. Documentation accuracy remains a review obligation under `SECURITY_ASSURANCE.md`; it is no
+longer claimed to be machine-enforced.
+
+**Validation.** `scripts/fork-guard-telemetry.test.sh` — 18 assertions covering both directions,
+including that an executable placed under `docs/` is still scanned, and that removing the `*.md`
+exclusion reproduces the original failure. Guard passes on the real tree; harness verified to
+report a failure when an expectation is inverted.
+
+**Related documentation.** `FORK_DIVERGENCE.md` (telemetry removal row); `.ai/divergence.md`;
+`.ai/quality-gates.md`.
+
+---
+
 ## 12. Items requiring provenance research
 
 Recorded so they are neither forgotten nor invented. **Do not write entries for these until the

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "env-check:app-store": "dotenv-checker --schema .env.appStore.example --env .env.appStore",
     "env-check:common": "dotenv-checker --schema .env.example --env .env",
     "fork:guard:telemetry": "bash scripts/fork-guard-telemetry.sh",
+    "fork:guard:telemetry:test": "bash scripts/fork-guard-telemetry.test.sh",
     "format": "biome format --write .",
     "heroku-postbuild": "turbo run @calcom/web#build",
     "lint:fix": "turbo lint:fix",

--- a/scripts/fork-guard-telemetry.sh
+++ b/scripts/fork-guard-telemetry.sh
@@ -8,6 +8,7 @@
 # enforceable instead of a one-time cleanup.
 #
 # Run locally:  yarn fork:guard:telemetry
+# Test locally: yarn fork:guard:telemetry:test
 # Runs in CI:   .github/workflows/forte-ci.yml (blocking)
 
 set -euo pipefail
@@ -23,17 +24,28 @@ report() {
 # Only tracked files, so a stray local build artefact or an unrelated node_modules copy
 # cannot fail the build.
 #
-# The exclusions are the places that must be able to *name* what was removed in order to
-# document it — this guard itself, the fork's operational layer, the workflow that runs it,
-# and the README section explaining the removal. Everything else, including the other
-# hardening docs, stays in scope: re-advertising CALCOM_TELEMETRY_DISABLED as a control in
-# hardening-checklist.md is exactly the regression worth failing on.
+# The invariant is behavioural: telemetry must not return in any surface that can *execute
+# or configure* it — application and package source, scripts, build/runtime config, Docker,
+# CI workflows. Documentation has to be able to name the endpoint, the key and the flag in
+# order to record that they were removed; prose cannot re-arm anything.
+#
+# Excluded by file semantics (extension), never by directory. A directory exclusion would
+# let an executable bypass the guard by being placed under the excluded path; an extension
+# rule cannot, so `docs/deploy.sh` and `.ai/anything.yml` stay in scope. The guard's own
+# source is the one unavoidable exception — it must contain the literals it searches for.
+#
+# Deliberately no longer covered: this guard used to fail when a hardening doc re-advertised
+# CALCOM_TELEMETRY_DISABLED as a live control. A fixed-string search cannot distinguish
+# "records that it was removed" from "claims it still works", which is why it fired on every
+# audit record that named it. That documentation-accuracy concern is real, but it is a review
+# question rather than a grep question — see SECURITY_ASSURANCE.md.
+#
+# Both directions are covered by scripts/fork-guard-telemetry.test.sh.
 tracked_grep() {
   git grep -n --fixed-strings -- "$1" -- \
     ':!scripts/fork-guard-telemetry.sh' \
-    ':!.ai/' \
-    ':!.github/workflows/forte-ci.yml' \
-    ':!README.md' \
+    ':!*.md' \
+    ':!*.mdx' \
     2>/dev/null || true
 }
 

--- a/scripts/fork-guard-telemetry.test.sh
+++ b/scripts/fork-guard-telemetry.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/fork-guard-telemetry.sh.
+#
+# Both directions are asserted: a guard that never fires and a guard that always fires are
+# equally useless. The always-fires case is not hypothetical — the documentation exclusion
+# below exists because the guard failed `develop` for naming the flag it had removed.
+#
+# Fixtures run in throwaway git repos. The real working tree is never touched and nothing is
+# added to its index. The protected literals are assembled at run time from fragments so that
+# this file does not contain them contiguously — otherwise it would need its own entry in the
+# very exclusion list under test.
+#
+# Run locally:  yarn fork:guard:telemetry:test
+# Runs in CI:   .github/workflows/forte-ci.yml
+
+set -euo pipefail
+
+guard="$(cd "$(dirname "$0")" && pwd)/fork-guard-telemetry.sh"
+[ -f "$guard" ] || { echo "guard not found: $guard" >&2; exit 1; }
+
+join() { local IFS=''; printf '%s' "$*"; }
+ENDPOINT="$(join 't.calendso' '.' 'com')"
+FLAG="$(join 'CALCOM_TELEMETRY' '_DISABLED')"
+WRITE_KEY="$(join 's2s.2pvs2bbpqq1zxna97wcml' '.' 'esb6cikfrf7yn0qoh1nj1')"
+NEXT_COLLECT="$(join '"next' '-collect"')"
+
+passed=0
+failed=0
+
+# One parent directory for every fixture: fixture_repo runs inside a command substitution,
+# so anything it appends to a shell array would be lost with the subshell. Nesting the
+# fixtures under WORK keeps cleanup to a single unconditional rm, which also avoids a
+# conditional as the EXIT trap's last command — that leaks its status into the exit code.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Builds a minimal repo containing only the guard, so unrelated repository content cannot
+# influence the result.
+fixture_repo() {
+  local dir
+  dir="$(mktemp -d "$WORK/fixture.XXXXXX")"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "guard-test@example.invalid"
+  git -C "$dir" config user.name "guard test"
+  mkdir -p "$dir/scripts"
+  cp "$guard" "$dir/scripts/fork-guard-telemetry.sh"
+  printf '%s' "$dir"
+}
+
+write() { mkdir -p "$(dirname "$1/$2")"; printf '%s\n' "$3" > "$1/$2"; }
+
+run_guard() {
+  local dir="$1" rc=0
+  git -C "$dir" add -A >/dev/null 2>&1
+  bash "$dir/scripts/fork-guard-telemetry.sh" >/dev/null 2>&1 || rc=$?
+  printf '%s' "$rc"
+}
+
+# expect_pass/expect_fail: exit 0 means "telemetry stays removed", exit 1 means the guard fired.
+assert() {
+  local name="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    printf '  ok    %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL  %s — expected exit %s, got %s\n' "$name" "$want" "$got"
+    failed=$((failed + 1))
+  fi
+}
+
+echo "fork-guard telemetry — regression tests"
+echo
+echo "documentation must NOT trip the guard (exit 0):"
+
+d="$(fixture_repo)"
+write "$d" "docs/AUDIT_EVIDENCE.md" "The fork removed the $ENDPOINT endpoint and the $FLAG flag."
+assert "root-level docs/*.md may name endpoint and flag" 0 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "FORK_IMPLEMENTATION_LEDGER.md" "Removed: $FLAG, key $WRITE_KEY, host $ENDPOINT."
+assert "root governance *.md may name endpoint, key and flag" 0 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" ".ai/hardening-checklist.md" "$FLAG was removed; it gates nothing."
+assert ".ai/*.md may name the flag" 0 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "apps/docs/content/troubleshooting.mdx" "Note: $FLAG is not used by this fork."
+assert "*.mdx may name the flag" 0 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+assert "clean repository passes" 0 "$(run_guard "$d")"
+
+echo
+echo "executable / configuration surfaces MUST trip the guard (exit 1):"
+
+d="$(fixture_repo)"
+write "$d" "packages/lib/analytics.ts" "export const flag = process.env.$FLAG;"
+assert "TypeScript source" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "apps/web/lib/collect.js" "const host = '$ENDPOINT';"
+assert "JavaScript source" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "packages/lib/key.mjs" "export const k = '$WRITE_KEY';"
+assert "ESM source carrying the write key" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "scripts/deploy.sh" "export $FLAG=1"
+assert "shell script" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "Dockerfile" "ARG $FLAG=1"
+assert "Dockerfile" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" ".github/workflows/deploy.yml" "  build-args: $FLAG=1"
+assert "CI workflow YAML" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" ".ai/generated-config.yml" "flag: $FLAG"
+assert "non-Markdown file under .ai/ (blanket directory exemption is gone)" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" ".env.example" "$FLAG=1"
+assert "environment configuration example" 1 "$(run_guard "$d")"
+
+# The reason the exclusion is by extension and not by directory.
+d="$(fixture_repo)"
+write "$d" "docs/deploy.sh" "export $FLAG=1"
+assert "executable moved under docs/ cannot bypass the guard" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "packages/lib/telemetry.ts" "// restored"
+assert "restored packages/lib/telemetry.ts" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "package.json" "{ \"dependencies\": { $NEXT_COLLECT: \"^1.0.0\" } }"
+assert "next-collect declared in package.json" 1 "$(run_guard "$d")"
+
+d="$(fixture_repo)"
+write "$d" "yarn.lock" "\"next-collect@npm:1.0.0\":"
+assert "next-collect present in yarn.lock" 1 "$(run_guard "$d")"
+
+echo
+echo "the documentation exclusion is what makes the positive cases pass:"
+
+# Strip the *.md exclusion back out and confirm the original failure returns. This is the
+# PR #41 condition, reproduced rather than asserted.
+d="$(fixture_repo)"
+sed -i.bak "/':\!\*\.md'/d" "$d/scripts/fork-guard-telemetry.sh"
+rm -f "$d/scripts/fork-guard-telemetry.sh.bak"
+write "$d" "docs/AUDIT_EVIDENCE.md" "The fork removed the $FLAG flag."
+assert "without the *.md exclusion, documentation trips the guard again" 1 "$(run_guard "$d")"
+
+echo
+if [ "$failed" -ne 0 ]; then
+  printf '\033[31m%s passed, %s FAILED\033[0m\n' "$passed" "$failed"
+  exit 1
+fi
+printf '\033[32mfork-guard telemetry tests: %s passed\033[0m\n' "$passed"
+exit 0


### PR DESCRIPTION
## Problem

The telemetry reintroduction guard correctly protects cal.forte's deliberate telemetry
removal, but it currently scans documentation text as though it were executable/product
configuration.

After the governance documentation landed (#41), `develop` became red because audit and
implementation records legitimately *name* the removed telemetry indicators:

```
FORK_IMPLEMENTATION_LEDGER.md:573,582,607
docs/EXTERNAL_FORK_INTAKE.md:246
docs/EXTERNAL_FORK_INTAKE_EVIDENCE.md:1224,1342
```

All six hits are prose describing what was removed. **No telemetry behavior was
reintroduced.** This is a false-positive scope defect in the guard, not a security
regression in the product.

Because `develop` itself is red, this currently blocks every other PR into `develop`.

## Security invariant

The guard must continue to reject telemetry/reporting behavior — or its enabling
configuration — in executable product, build, runtime and deployment surfaces.

Documentation must be able to describe those indicators. Prose cannot re-arm anything.

## Change

- exclude Markdown/MDX documentation **by file semantics** (`*.md`, `*.mdx`)
- preserve every protected telemetry indicator, unchanged
- preserve blocking behavior in `forte-ci`
- remove the now-unnecessary broad path exclusions (`.ai/`, `README.md`, `forte-ci.yml`)
- add deterministic positive and negative regression coverage

**The correction must not become a `docs/**` bypass — and it isn't one.** Exclusion is by
extension, never by directory, so an executable file placed under `docs/` is still scanned.
A `:!docs/**` rule would have opened exactly that hole; this does not.

Coverage is **net wider**, not narrower. Every tracked occurrence of every protected literal
in the repository is in a `.md` file, except the guard's own source. `.ai/` contains only
Markdown (15 files), and `forte-ci.yml` never contained a protected literal — so nothing
relied on those blanket exemptions. Dropping them brings CI workflow YAML, and any future
non-Markdown file under `.ai/`, into scope for the first time. That matters: the rejected
Fly.io intake candidate recorded in `docs/EXTERNAL_FORK_INTAKE.md` was precisely a workflow
setting a telemetry build arg.

### One check deliberately given up

The guard previously failed if a hardening doc re-advertised the opt-out flag as a *live
control*. A fixed-string search cannot distinguish "records that it was removed" from
"claims it still works" — which is exactly why it fired on the audit set. That remains a
review obligation under `SECURITY_ASSURANCE.md`; it is no longer claimed to be
machine-enforced. Documented in the script rather than dropped silently.

## Validation

All results below were run on this branch at `c62c42d068`, not asserted:

| Check | Result |
| --- | --- |
| Real repository guard | **passes** (exit 0) — previously exit 1 |
| Documentation fixture (`docs/*.md`, root `*.md`, `.ai/*.md`, `*.mdx`) | **passes** (exit 0) |
| Executable-source fixture (`.ts`, `.tsx`, `.js`, `.mjs`, `.cjs`, `.sh`) | **fails** (exit 1) |
| Runtime/build config fixture (Dockerfile, compose, workflow YAML, `.env*`, `turbo.json`) | **fails** (exit 1) |
| Regression assertions | **18/18 pass** |
| Executable moved under `docs/` (`docs/deploy.sh`) | **still scanned** (exit 1) |
| Symlink `alias.md -> real.sh` | target still scanned — no bypass |
| Protected indicators vs `develop` | byte-identical; nothing weakened |
| Blocking behavior | preserved (`continue-on-error` is on the Biome step only) |
| Product behavior | unchanged — no `apps/` or `packages/` path in the diff |
| Telemetry functionality | none restored; `packages/lib/telemetry.ts` still absent |

A broader bypass sweep covered 32 executable/config surfaces — `.ts .tsx .js .jsx .mjs .cjs
.py .sh .bash`, `Dockerfile(.prod)`, compose, k8s YAML, workflow YAML, `.env*`,
`next.config.js`, `turbo.json`, `tsconfig.json`, `Makefile`, `.toml/.ini/.properties`,
`vendor/*.go`, and the same paths under `docs/` and `.ai/`. **All 32 are scanned.**

Two residuals, stated rather than papered over: a `.md` file with the executable bit set and
a shebang is exempt (contrived — nothing here executes Markdown), and the guard's own source
must stay exempt because it necessarily contains the literals it searches for.

### Testability

`scripts/fork-guard-telemetry.test.sh` runs fixtures in throwaway git repos — the real
working tree is never touched and nothing is added to its index. The protected literals are
assembled at run time from fragments so the test file does not contain them contiguously,
which would otherwise require its own entry in the very exclusion list under test.

The suite asserts both directions, including that removing the `*.md` exclusion reproduces
the original failure. The harness was itself verified to report a failure when an
expectation is inverted (`17 passed, 1 FAILED`, exit 1) — a test suite that cannot fail is
not evidence.

It is wired into `forte-ci` as a blocking step, so a guard that stops firing fails the build.

## Governance

**Type:** `MAINTENANCE` / `SECURITY_GUARD_CORRECTION`
**Implementation ledger:** `FIL-0013`

This is **not** a vulnerability fix. The protected invariant was never breached, no telemetry
behavior returned, and no product code is touched. The guard's scan scope has been made
semantically accurate.

Definition of Done (`FORK_PROCESS.md`) — implementation relationship `CAL_FORTE_NATIVE`,
source usage `NONE`, licence disposition `PERMISSIVE_COMPATIBLE`; recorded in
`FORK_IMPLEMENTATION_LEDGER.md` §11. `FORK_DIVERGENCE.md` needs no change: its claim that
"a blocking guard prevents reintroduction" remains true.
