### PR TITLE
test: verify required ci enforcement (TEMPORARY — do not merge)

### DIFF
--- a/.ci-verification/temporary-fixture.txt
+++ b/.ci-verification/temporary-fixture.txt
@@ -1,0 +1,4 @@
+Temporary fixture for issue #47 branch-protection verification.
+This file exists only to deterministically fail scripts/fork-guard-telemetry.sh
+by naming the flag it protects: CALCOM_TELEMETRY_DISABLED
+This file and its branch are deleted after verification evidence is collected.


### PR DESCRIPTION
Temporary branch-protection verification for issue #47.

Deliberately trips `scripts/fork-guard-telemetry.sh` via a tracked fixture
naming `CALCOM_TELEMETRY_DISABLED`, so the required `ci` check fails.

Purpose: prove `develop`'s new required status check mechanically blocks
merge when `ci` fails — including for the repository admin.

**This PR will be closed and the branch deleted once evidence is collected.
Do not merge.**