### PR TITLE
ci(governance): enforce required quality checks

### DIFF
--- a/.ai/quality-gates.md
+++ b/.ai/quality-gates.md
@@ -25,6 +25,22 @@ For fork/release work:
   upstream telemetry module, its Jitsu endpoint/key, `next-collect`, or the
   `CALCOM_TELEMETRY_DISABLED` flag reappear through a sync
 
+## Mechanically enforced branch protection
+
+Prior to issue #47, every gate above was convention only — nothing in GitHub prevented a
+merge with `forte-ci` failing. `develop` sat red for over an hour on 2026-08-26 as a direct
+consequence: PR #41 merged while the telemetry guard was failing, which meant the following
+`Type check` and `Lint` steps had been silently skipped for that entire window. See
+[FORK_PROCESS.md](../FORK_PROCESS.md) → *Branch Contract and Required Checks* for what is
+actually enforced, and why `main` deliberately keeps a different policy from `develop` and
+`release`.
+
+The load-bearing distinction: **required status checks** (`develop`, `release`) are a
+mechanical merge blocker; **report-only scanners** (CodeQL, Trivy, Scorecard) are visible
+findings a human evaluates, per `SECURITY_ASSURANCE.md` §5b.3 — converting them into blocking
+gates wholesale is deliberately rejected there, because their severity alone does not equal
+applicability, reachability, or shipped-component status.
+
 **No markdown gate exists.** `biome check docs/` reports *"Checked 1 file"* — Biome has no markdown
 support configured here, and `lint-staged.config.mjs` covers only `js/ts/jsx/tsx` plus
 `schema.prisma`. Documentation formatting and link integrity are therefore **not** machine-verified

--- a/FORK_PROCESS.md
+++ b/FORK_PROCESS.md
@@ -32,6 +32,57 @@ The goal is a simple operating model:
   - Tags represent reviewed release points.
   - Tags are the release inputs that downstream secure deployment should trust.
 
+## Branch Contract and Required Checks
+
+Everything above is convention; this section is what GitHub actually enforces, as of issue
+#47. Re-read via `gh api repos/rubennati/cal.diy/branches/<branch>/protection` before trusting
+this table — this document records a decision, not a live API mirror.
+
+| Branch | Protected | PR required | Required status check | Approvals | Force-push | Deletion | `enforce_admins` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `main` | yes | no | none | none | blocked | blocked | false |
+| `develop` | yes | yes | `ci` (strict) | 0 | blocked | blocked | true |
+| `release` | yes | yes | `ci` (strict) | 0, code-owner | blocked | blocked | true |
+
+**Why `main` differs.** `main` is the upstream mirror; none of `forte-ci`, `forte-codeql` or
+`forte-trivy` trigger there at all — their `on:` blocks are scoped to `develop`/`release` only.
+Requiring `ci` on `main` would not raise the bar, it would make `main` permanently unmergeable,
+since the check that would need to pass never runs. `main`'s existing protection (no force-push,
+no deletion) is left as-is.
+
+**Why `ci` and not a scanner.** The single required check is the `ci` job from
+`.github/workflows/forte-ci.yml` — GitHub's job id, not the workflow's display name
+(`forte-ci`). It covers lifecycle-script integrity, the telemetry fork guard and its self-test,
+`type-check:ci`, and Biome. CodeQL, Trivy and Scorecard stay **report-only** and are not
+required checks anywhere — see `SECURITY_ASSURANCE.md` §5b.3, which argues against converting
+vulnerability scanners into blocking gates wholesale, since scanner severity alone does not
+establish applicability or reachability. Recent evidence for this fork includes both genuine
+fixes (Zoho, Intercom, Vitest) and reviewed false positives (Giphy, `useBooking`, four Stripe
+placeholder findings) — a severity-only gate would have blocked merges on the false positives
+too.
+
+**`enforce_admins: true` on `develop` and `release`.** With a single maintainer, a check that
+can be silently bypassed during an ordinary merge is not mechanically enforced at all — it is
+the same convention-only gate this section replaces, wearing a different label. `enforce_admins`
+closes that: the maintainer cannot merge past a failing required check in the normal PR-merge
+flow. This is deliberately **not** the same thing as being permanently locked out — recovery
+from a broken or over-strict gate is an explicit `PATCH` to branch protection (a visible,
+attributable settings change), never an invisible bypass folded into a routine merge.
+
+**Zero required approvals.** Both `develop` and `release` require a pull request but 0
+approving reviews, because the sole maintainer cannot approve their own PR — a `>0` requirement
+would create a self-review deadlock GitHub does not resolve. `release` additionally requires a
+code-owner review via the existing `.github/CODEOWNERS` (`@rubennati` for `.github/`), which
+predates this issue and is preserved unchanged.
+
+**Verification, not merely stated.** After a deliberately failing `ci` was pushed on a temporary
+branch, [PR #51](https://github.com/rubennati/cal.diy/pull/51) showed `mergeable_state: blocked`
+(REST) and `mergeStateStatus: BLOCKED` (the CLI's GraphQL-backed view) — both re-read from the
+API after the fact, not merely observed once. The failing step was exactly the intended one
+(the telemetry guard), which also confirmed steps 8-10 skip on that failure the same way they
+did during the original 2026-08-26 incident. The PR was closed unmerged and the temporary
+branch deleted immediately after; it never reached `develop`.
+
 ## Allowed Fork Divergence
 
 Fork-owned changes should stay small and obvious.

--- a/SECURITY_ASSURANCE.md
+++ b/SECURITY_ASSURANCE.md
@@ -202,6 +202,12 @@ Do not run every expensive tool on every change. Four tiers, by what a false neg
 
 ### Tier 1 — PR / fast gates *(minutes; blocks merge)*
 
+"Blocks merge" means the `ci` job is a required status check on `develop` and `release`, with
+`enforce_admins` on — see [FORK_PROCESS.md → Branch Contract and Required
+Checks](FORK_PROCESS.md#branch-contract-and-required-checks) for the enforced settings and why
+`main` is excluded. Before issue #47, nothing enforced this claim mechanically; `develop` sat red
+for over an hour on 2026-08-26 as a direct result.
+
 | Check | Status |
 | --- | --- |
 | `yarn type-check:ci` | **exists**, blocking |


### PR DESCRIPTION
## Problem

Issue #47: the fork's process documents (`forte-ci.yml`'s "Blocking on purpose" comment,
`.ai/quality-gates.md`, `SECURITY_ASSURANCE.md` §5b.3) all treated selected checks as
blocking, but **nothing enforced any of it**. `develop` had no branch protection at all;
`main` and `release` had protection but zero required status checks and
`enforce_admins: false`. This was not hypothetical: `develop` sat red for over an hour on
2026-08-26 because PR #41 merged while the telemetry guard was failing, silently skipping
Type check and Lint.

## What changed

**`develop`** — was unprotected. Now: PR required, 0 approving reviews (single maintainer,
can't self-approve), required status check `ci` (strict/up-to-date), force-push and
deletion disabled, `enforce_admins: true`.

**`release`** — existing protections (PR + code-owner review via `.github/CODEOWNERS`,
force-push/deletion disabled) preserved unchanged, plus the same required `ci` check and
`enforce_admins` raised `false` → `true`.

**`main`** — deliberately **unchanged**. None of `forte-ci`, `forte-codeql` or
`forte-trivy` trigger on `main` at all (`on:` blocks scope to `develop`/`release` only), so
requiring `ci` there would make `main` permanently unmergeable rather than raise the bar.
`main` is the upstream-near mirror, not a reviewed integration branch — see
`FORK_PROCESS.md` → *Branch Contract and Required Checks* for the full reasoning.

**Scanners stay report-only.** CodeQL, Trivy and Scorecard are not required checks
anywhere. This is a deliberate continuation of `SECURITY_ASSURANCE.md` §5b.3's existing
position, not a new decision — converting vulnerability scanners into blocking gates on
severity alone would have blocked recent merges on reviewed false positives (Giphy,
`useBooking`) alongside genuine fixes (Zoho, Intercom, Vitest), which is exactly the
scanner-severity-≠-project-priority distinction that document already argues for.

## Check context

The required check is **`ci`** — the job id from `.github/workflows/forte-ci.yml`, not the
workflow's display name (`forte-ci`). Confirmed via `check-runs` on the current `develop`
HEAD and on the last several merged PR heads before touching any setting.

## `enforce_admins` reasoning

With a single maintainer, a check that can be silently bypassed during an ordinary merge
isn't mechanically enforced — it's the same convention-only gate this issue exists to
replace. `enforce_admins: true` closes that. This is deliberately not the same as being
locked out: recovery from an over-strict gate is an explicit, attributable branch-protection
settings change, never an invisible bypass folded into a routine merge.

## Verification (not assumed)

- **Settings write, then independent re-read.** Every value below was fetched fresh from
  `GET .../branches/<branch>/protection` after the `PUT`, not inferred from the write
  response.
- **Positive path.** `ci` runs and is visible as required on both `develop` and `release`;
  CodeQL/Trivy/Scorecard run but aren't required.
- **Negative path, proven live.** [PR #51](https://github.com/rubennati/cal.diy/pull/51) —
  a temporary branch with a tracked fixture naming `CALCOM_TELEMETRY_DISABLED` —
  deliberately failed the telemetry guard (step 7 of `ci`), which also skipped steps 8-10
  exactly as happened during the 2026-08-26 incident. Result: `mergeable_state: blocked`
  (REST) and `mergeStateStatus: BLOCKED` (GraphQL-backed CLI), both re-read from the API
  after the failure, not assumed from the settings alone. PR closed unmerged, branch
  deleted immediately after; the fixture never reached `develop`.
- **`main` re-read after the `develop`/`release` writes** to confirm it was untouched:
  `required_status_checks` absent, `enforce_admins: false`, unchanged from before this PR.

## Governance

No `FORK_IMPLEMENTATION_LEDGER.md` entry — issue #47 explicitly scopes this as repository
configuration, not product implementation, and the ledger's own rules don't require an
entry for a settings change touching no tracked application file. Enforcement semantics are
recorded once, in `FORK_PROCESS.md` → *Branch Contract and Required Checks*, cross-referenced
from `.ai/quality-gates.md` and `SECURITY_ASSURANCE.md` rather than duplicated across all
three.

## Note

This PR is itself now subject to the protection it documents — intentional, and part of the
positive-path evidence above.

Closes #47.
