### PR TITLE
test: verify release code-owner enforcement (TEMPORARY PROBE — DO NOT MERGE)

### DIFF
--- a/.github/workflows/forte-ci.yml
+++ b/.github/workflows/forte-ci.yml
@@ -2,6 +2,8 @@ name: forte-ci
 
 # Fork-owned CI. Runs only on the fork's working branches, never on `main`
 # (the pristine upstream mirror). Additive: upstream has no forte-* workflows.
+# TEMPORARY BRANCH-PROTECTION PROBE — this comment exists only to place a
+# CODEOWNERS-owned `.github/**` file in a probe PR diff. It must never merge.
 
 on:
   pull_request:


### PR DESCRIPTION
# ⚠️ TEMPORARY PROBE — MUST NEVER BE MERGED ⚠️

This PR exists solely to observe how `release` branch protection behaves for a
self-authored PR that touches a CODEOWNERS-owned path. It will be **closed without
merging** and its branch deleted as soon as the merge/review state has been recorded.

## No functional change

One comment added to `.github/workflows/forte-ci.yml`. Verified behaviourally inert:
stripping comments and blank lines from the file before and after the change yields
**byte-identical** content (41 effective lines both ways).

The comment's only purpose is to put a `.github/**` path — owned by `/.github/ @rubennati`
in `.github/CODEOWNERS` — into a PR diff targeting `release`.

## What is being tested

`release` protection currently has `require_code_owner_reviews: true`, `enforce_admins: true`,
and required status check `ci`. The sole code owner for `.github/**` is also the author of
this PR and of the upcoming release PR.

The open question — deliberately **not** assumed from configuration — is whether GitHub
therefore blocks the merge because the author cannot approve their own PR, which would make
the real develop→release PR unmergeable without a protection change.

This probe answers that empirically. No protection setting, CODEOWNERS entry, or reviewer
assignment is being changed to make it pass.

## Do not

- do not merge
- do not approve
- do not adjust branch protection to unblock it

Close it once the observation is recorded.
