### PR TITLE
docs(release): align promotion with protected release branch

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -42,60 +42,79 @@ git diff --check
 
 The target model is a source-identical promotion. Do not edit files during promotion.
 
-### One-time historical ancestry reconciliation
+`release` is a protected branch: it requires a pull request, requires the `ci` check, blocks
+force-push, and applies to administrators. **A direct `git push origin release` is refused —
+including for the maintainer.** Promotion therefore goes through a pull request like any
+other change.
 
-As of 2026-08-10, `origin/release` has five release-only commits ending at `f99367c3a7`
-and is not an ancestor of `origin/develop`. Therefore the first promotion under this
-process cannot fast-forward until that topology is reconciled. Do not force-push or reset
-the protected `release` branch.
-
-Use a dedicated reviewed branch from the then-current `origin/develop`. Record the old
-release history as ancestry with an **ours-strategy merge**; this preserves the reviewed
-`develop` tree while making `origin/release` an ancestor:
+### Normal promotion — pull request, merged with "Create a merge commit"
 
 ```bash
 git fetch origin --prune --tags
-git switch --create codex/reconcile-release-ancestry origin/develop
-git merge --strategy=ours --no-ff origin/release \
-  -m "chore(release): reconcile historical release ancestry"
-git diff --exit-code HEAD^1..HEAD
-git merge-base --is-ancestor origin/release HEAD
+
+# Confirm release is still contained in develop. If this fails, stop and
+# reconcile deliberately on develop; never force-push or reset release.
+git merge-base --is-ancestor origin/release origin/develop
+
+# The promotion PR needs a branch; it carries no commits of its own.
+git switch --create release-promotion/vX.Y.Z-N origin/develop
+git push origin release-promotion/vX.Y.Z-N
 ```
 
-The empty-tree merge commit must be reviewed, pass all `develop` gates, and reach
-`origin/develop` through the normal approved push/PR path. Only then use the fast-forward
-promotion below. This is a one-time topology repair, not a general release technique.
+Open a pull request from that branch into `release`, wait for `ci`, and merge it with
+GitHub's **"Create a merge commit"**. Do not use "Squash and merge" or "Rebase and merge".
 
-### Normal fast-forward promotion
+**Why a merge commit, and why not the alternatives.** All three methods are enabled on this
+repository, and only one preserves what the fork's own contracts require:
 
-```bash
-git fetch origin --prune --tags
-git switch release
-git merge --ff-only origin/develop
-git diff --exit-code origin/develop..release
-git push origin release
-```
+| Method | Resulting `release` tree | Effect on history |
+| --- | --- | --- |
+| **Create a merge commit** | **identical to `develop`** — the merge is trivially fast-forwardable, so it takes `develop`'s tree verbatim | keeps every reviewed commit and its SHA, including upstream authorship and `(cherry picked from commit …)` trailers |
+| Squash and merge | identical | collapses the whole delta into one synthetic commit — forbidden by [FORK_PROCESS.md](FORK_PROCESS.md) and by [UPSTREAM_REVIEW_LEDGER.md](UPSTREAM_REVIEW_LEDGER.md)'s `integrated-squashed` rule ("must not be created again") |
+| Rebase and merge | identical | rewrites every commit SHA and drops the PR merge commits, invalidating the `Local commit(s)` evidence recorded in [FORK_IMPLEMENTATION_LEDGER.md](FORK_IMPLEMENTATION_LEDGER.md) and breaking `release`↔`develop` ancestry |
 
-If fast-forward is impossible, stop. Do not create an ad-hoc release merge or resolve
-conflicts during promotion. Reconcile branch history deliberately on `develop`, rerun all
-gates, and try again.
+The release workflow checks the **tree**, not the commit SHA
+(`release_tree != develop_tree` is the failure condition in
+`.github/workflows/release-docker.yaml`), so a merge commit satisfies it exactly. Because
+`release` is always an ancestor of `develop` at promotion time, the merge introduces no
+content of its own — see the verification below, which proves this rather than assuming it.
 
-Until the one-time reconciliation is complete, stop before promotion. Do not replace the
-fast-forward with a release-side merge merely because `--ff-only` fails.
+### After merging: bring the merge commit back to `develop`
+
+The promotion merge commit exists only on `release`. Merge it back so `release` stays an
+ancestor of `develop` for the next cycle — the same pattern the `v6.2.0-5` history already
+follows. Do this **after** tagging, so `develop` does not move between the promotion and the
+tag; the workflow compares `release` against `origin/develop` at tag time.
 
 ## 3. Verify Before Tagging
 
 ```bash
 git fetch origin --prune --tags
-git diff --exit-code origin/develop..origin/release
-git status --short --branch
-git log --oneline origin/release..origin/develop
+
+# 1. release contains the approved candidate
+git merge-base --is-ancestor origin/develop origin/release
+
+# 2. the trees are identical — this is what release-docker.yaml actually checks
+test "$(git rev-parse origin/release^{tree})" = "$(git rev-parse origin/develop^{tree})"
+
+# 3. no release-only diff was introduced by the promotion
+git diff --exit-code origin/develop origin/release
+
+# 4. the tag name is still free
 git tag --list 'vX.Y.Z-N'
 ```
 
-Confirm `forte-ci` succeeded for the exact `release` SHA. GitHub branch protection and tag
-rulesets should require review and prevent force-push/tag deletion; these repository
-settings must be verified in GitHub because they are not versioned in this repository.
+All four commands must succeed silently. Check 2 is the one the release workflow enforces;
+checks 1 and 3 catch a promotion that carried unintended content.
+
+Then confirm on GitHub that **`forte-ci`, `forte-codeql` and `forte-trivy` each have a
+successful `push`-event run on `release` for the exact promoted SHA** — the workflow's
+`Require successful release gates for exact source SHA` step queries all three and refuses to
+publish otherwise. Merging the promotion PR triggers them; wait for them before tagging.
+
+GitHub branch protection and tag rulesets should require review and prevent
+force-push/tag deletion; these repository settings must be verified in GitHub because they
+are not versioned in this repository.
 
 ## 4. Create And Push The Release Tag
 


### PR DESCRIPTION
Documentation only. **No release operation performed** — no promotion PR, no tag, no image.

## The inconsistency

`RELEASE_PROCESS.md` §2 instructed the operator to promote with:

```
git merge --ff-only origin/develop
git push origin release
```

That path **cannot execute**. `release` requires a pull request and the `ci` check, blocks
force-push, and has `enforce_admins: true` — so the direct push is refused for everyone,
including the maintainer. `FORK_PROCESS.md` already documents this enforced state; the
runbook had not caught up.

The section also still opened with a *one-time ancestry reconciliation* presented as a
blocking precondition — "five release-only commits ending at `f99367c3a7`", "cannot
fast-forward until that topology is reconciled". That work completed in `a4e2ff5dcd`.
Live now: `release` is a strict ancestor of `develop`, `develop..release` = **0 commits**.
The section described a topology that no longer exists and stood between the reader and the
normal path.

## Selected method: "Create a merge commit"

Evidence, not preference. All three merge methods are enabled
(`allow_merge_commit`/`allow_squash_merge`/`allow_rebase_merge` all `true`,
`required_linear_history: false`):

| Method | Resulting tree | History outcome |
| --- | --- | --- |
| **Merge commit** ✅ | **identical to `develop`** | preserves all 38 commits and their SHAs |
| Squash ❌ | identical | forbidden by `FORK_PROCESS.md` and `UPSTREAM_REVIEW_LEDGER.md`'s `integrated-squashed` rule — *"must not be created again"* |
| Rebase ❌ | identical | rewrites all 26 non-merge SHAs, drops the 12 PR merges |

**Tree identity verified empirically**, by constructing the exact merge commit GitHub would
create and inspecting it — not by reasoning about it:

```
simulated merge tree: 023e05f0466dfa344228ddb6c6b677a0111b1b4d
develop^{tree}:       023e05f0466dfa344228ddb6c6b677a0111b1b4d  → identical
diff vs develop:      empty
develop ancestor of merge: yes
```

(The temporary object was never referenced or pushed.)

**Why rebase is specifically damaging here.** Two commits in the delta carry upstream
authorship and `(cherry picked from commit …)` trailers — `da40b51567` (KATHIR ESWARAN,
from `07a288bbd8`) and `943f646850` (Bandhan Majumder, from `717fed8f86`). Eight
`FORK_IMPLEMENTATION_LEDGER.md` entries cite delta SHAs as `Local commit(s)` evidence.
Rebasing would invalidate all of it and break `release`↔`develop` ancestry.

## Release-workflow compatibility

`release-docker.yaml` compares **trees**, not commit SHAs:

```
release_tree="$(git rev-parse "$release_sha^{tree}")"
develop_tree="$(git rev-parse refs/remotes/origin/develop^{tree})"
if [[ "$release_tree" != "$develop_tree" ]]; then ... exit 1
```

A merge commit satisfies this exactly. It separately requires the **tag commit to equal
`origin/release` HEAD**, so the tag is created *after* the promotion merge — and `develop`
must not move between promotion and tag, since the tree comparison happens at tag time.
Both constraints are now stated in the runbook.

The `v6.2.0-5` history already follows this shape: the current `release` HEAD
(`41689d1d6e`) is itself a two-parent PR merge commit, and `release` is still an ancestor
of `develop` because it was later merged back. The updated runbook records that back-merge
step explicitly rather than leaving it as folklore.

## Also corrected

Pre-tag verification now proves the four properties that matter — `release` contains the
candidate, `release^{tree} == develop^{tree}`, no release-only diff, tag name free — and
records that the workflow requires successful **`forte-ci`, `forte-codeql` *and*
`forte-trivy`** push-event runs on `release` for the exact promoted SHA. The previous text
mentioned only `forte-ci`; the workflow loops over all three and refuses to publish
otherwise.

## Scope

One file, `RELEASE_PROCESS.md`. No product/runtime code, no dependencies, no workflow
behavior, no branch protection, no governance abstraction added — the existing runbook was
corrected rather than supplemented.
