### PR TITLE
ci: make the two fast-path checks state what they verified

### DIFF
--- a/.github/workflows/forte-ci.yml
+++ b/.github/workflows/forte-ci.yml
@@ -125,12 +125,18 @@ jobs:
 
       - name: Whitespace and conflict-marker check
         shell: bash
+        # Says what it compared. A clean `git diff --check` prints nothing, so
+        # without this the step's success is indistinguishable in the log from it
+        # having silently skipped — and on the fast path this is one of only two
+        # checks standing between the change and a green required context.
         run: |
           set -euo pipefail
-          if git rev-parse -q --verify HEAD^1 >/dev/null; then
-            git diff --check HEAD^1 HEAD
+          if base="$(git rev-parse -q --verify HEAD^1)"; then
+            echo "Checking $base..$(git rev-parse HEAD)"
+            git diff --check "$base" HEAD
+            echo "No whitespace errors or conflict markers introduced."
           else
-            echo "No parent commit available to diff against; skipping."
+            echo "::warning::HEAD has no first parent here, so nothing was compared."
           fi
 
       # ---------------------------------------------------------------------
@@ -175,7 +181,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ steps.scope.outputs.mode }}" == "fast" ]]; then
-            echo "Documentation/presentation change: guards and whitespace check passed; install, type-check and lint intentionally skipped." >> "$GITHUB_STEP_SUMMARY"
+            echo "Markdown-only change: fork guards and whitespace check passed; install, type-check and lint intentionally skipped. This run is not evidence that the tree type-checks." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "Full validation completed." >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
Recovers `0cd1d3c3ac`, which was pushed to `ci/pr-fast-path` about ninety seconds after [PR #62](https://github.com/rubennati/cal.diy/pull/62) had already merged at `00cb4797e0`. A push to the branch of a merged PR raises no `synchronize` event, so the commit never entered that PR and never reached `develop`. Cherry-picked with `-x`; no other change.

## What it fixes

**The run summary.** It still said "Documentation/presentation change" after the allowlist was narrowed from `docs/**` to the `.md` extension in `00cb4797e0`, and it did not say what a fast-path run stops proving. It now says both.

**The whitespace check.** `git diff --check` prints nothing on success, which left the step's log indistinguishable from it having skipped. Establishing which had actually happened on run [33153709188](https://github.com/rubennati/cal.diy/actions/runs/33153709188) took three passes — the first used a grep that matched the *echoed script source* rather than step output and returned the wrong answer outright. On the fast path this is one of only two checks standing between a change and a green required context, so silence there is the wrong default. It now prints the range it compared and raises a warning annotation if there was nothing to compare.

No behavioural change to classification, and nothing here alters what runs on which path.

## Expected CI path

This touches `.github/workflows/forte-ci.yml`, so it must take the **full** path.