### PR TITLE
docs: record how FIL-0022 actually landed, across two pull requests

### DIFF
--- a/FORK_IMPLEMENTATION_LEDGER.md
+++ b/FORK_IMPLEMENTATION_LEDGER.md
@@ -1978,8 +1978,8 @@ The completion rule these steps serve is
 | Type | `GOVERNANCE` / `MAINTENANCE_BOUNDARY` / `CI_ENFORCEMENT` |
 | GitHub issue | n/a — maintainer request, no tracking issue filed |
 | Code-scanning alert | n/a |
-| PR | [#62](https://github.com/rubennati/cal.diy/pull/62) |
-| Local commit(s) | `32584ba05b` |
+| PR | [#62](https://github.com/rubennati/cal.diy/pull/62), [#63](https://github.com/rubennati/cal.diy/pull/63) |
+| Local commit(s) | `32584ba05b`, `00cb4797e0`, merged as `689bb82f96` |
 | Released in | not yet released |
 | Implementation relationship | `CAL_FORTE_NATIVE` |
 | Source usage | `NONE` |
@@ -2066,9 +2066,18 @@ path now fails fast on a guard violation instead of after a four-minute install.
 direction. It removes no enforced signal (the skipped steps covered nothing about the
 allowlisted files) and adds two blocking checks that previously ran later or not at all.
 
-**Rollback.** Revert `32584ba05b`. Because the change is confined to workflow files and
-documentation, reverting restores the prior behaviour exactly, with no branch-protection or
-registry state to unwind.
+**Split across two PRs, and why.** PR #62 merged at `00cb4797e0` while a follow-up commit was
+still being prepared. That commit was pushed to the branch about ninety seconds later, and a
+push to the branch of an already-merged PR raises no `synchronize` event — so it neither
+entered #62 nor reached `develop`, and the CI run that would have confirmed it never started.
+It is recovered by PR #63 (`git cherry-pick -x`). This is the second occurrence of the pattern
+in this repository; the first was the FIL-0018 wording correction after PR #54. The general
+lesson is recorded rather than the incident: after pushing to a branch, confirm the PR is still
+open before waiting on a run, because a merged PR absorbs no further pushes.
+
+**Rollback.** Revert `32584ba05b` and `00cb4797e0`. Because the change is confined to workflow
+files and documentation, reverting restores the prior behaviour exactly, with no
+branch-protection or registry state to unwind.
 
 **Upstream reevaluation trigger.** N/A — `forte-*` workflows are fork-owned and additive;
 upstream has no equivalent file to diverge from. Revisit the allowlist if a future change ever


### PR DESCRIPTION
Updates FIL-0022 with what actually happened: [PR #62](https://github.com/rubennati/cal.diy/pull/62) merged as `689bb82f96` at `00cb4797e0`, and one follow-up commit missed that merge and is recovered by [PR #63](https://github.com/rubennati/cal.diy/pull/63).

The ledger records the general lesson rather than the incident — after pushing to a branch, confirm the PR is still open before waiting on a run, because a merged PR absorbs no further pushes. This is the second occurrence of the pattern here; the first was the FIL-0018 wording correction after PR #54.

## This PR is also the fast path's first live test

`FORK_IMPLEMENTATION_LEDGER.md` is the only changed file, so this is the first genuinely markdown-only pull request since the fast path reached `develop`. PR #62 could not demonstrate this itself: for a `pull_request` event GitHub runs the workflow from the merge ref, so any PR *carrying* the new workflow necessarily also changes a non-markdown path.

Expected on `ci`:

- `Classify change scope` reports `Every changed path is markdown -> fast path.`
- the four fork guards and the whitespace check run
- setup-node, corepack, install, lifecycle check, type-check and Biome are all **skipped**
- `ci` still reports, green, as the required status context
- `forte-codeql` does not run at all, via `paths-ignore` — harmless, since it is not a required context

Against the ~8m52s that run [33153709188](https://github.com/rubennati/cal.diy/actions/runs/33153709188) took on the full path, this should finish in well under a minute.