### PR TITLE
docs: correct the stale latest-release references after v6.2.0-6

### DIFF
--- a/FORK_DIVERGENCE.md
+++ b/FORK_DIVERGENCE.md
@@ -25,8 +25,8 @@ Last reconciled: **2026-08-11**
 | --- | --- |
 | Upstream base | Cal.com 6.2.0 at merge-base `46eb533dbd` |
 | Upstream reviewed through | `176037d0af` on 2026-08-10 |
-| Latest published fork baseline | `201b016984` |
-| Latest published fork release | `v6.2.0-5` |
+| Latest published fork baseline | `9b9df424e3` |
+| Latest published fork release | `v6.2.0-6` |
 | Exact source comparison | [`main...develop`](https://github.com/rubennati/cal.diy/compare/main...develop) |
 
 `Released` below names the first fork release known to contain the change. `Unreleased`

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ compromise; every change here is deliberate and documented.
 **Fork changes:** Security defaults, telemetry, CI, container runtime, and release handling
 intentionally differ from Cal.diy. [See the public divergence register →](FORK_DIVERGENCE.md)
 
-**Latest release:** [`v6.2.0-5`](https://github.com/rubennati/cal.diy/tree/v6.2.0-5)
-from [`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe13388ccdc6a82f2669e9719d3bcc).
+**Latest release:** [`v6.2.0-6`](https://github.com/rubennati/cal.diy/releases/tag/v6.2.0-6)
+from [`9b9df424e3`](https://github.com/rubennati/cal.diy/commit/9b9df424e3f3ad94fd4a5fc4c5387764f1dbce65).
 [Full release evidence →](FORK_STATUS.md#latest-release-evidence)
 
 ## Branch model
@@ -52,11 +52,11 @@ from [`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe1338
 ## Releases
 
 The latest published image was built from `release` at
-[`201b016984`](https://github.com/rubennati/cal.diy/commit/201b016984fe13388ccdc6a82f2669e9719d3bcc):
+[`9b9df424e3`](https://github.com/rubennati/cal.diy/commit/9b9df424e3f3ad94fd4a5fc4c5387764f1dbce65):
 
-- AMD64: `ghcr.io/rubennati/cal.diy:v6.2.0-5@sha256:c2facc284b28e1eea76b6d82c02e680d20d648dc255ef7f74520dbf30d18b17e`
-- ARM64: `ghcr.io/rubennati/cal.diy:v6.2.0-5-arm@sha256:dffa387024a68b9b057b1bdf3342a21b699bb092da4f711932f129bd932faeae`
-- Evidence: [Release Docker run 31435807941](https://github.com/rubennati/cal.diy/actions/runs/31435807941)
+- AMD64: `ghcr.io/rubennati/cal.diy:v6.2.0-6@sha256:538cbb4a22733d262057c4b2a47c700117766816f57732925b077267a0dbe0f1`
+- ARM64: `ghcr.io/rubennati/cal.diy:v6.2.0-6-arm@sha256:5b2ffcb7fc0e752a40f079a4d580571da680af91238b0bdf1dbe170f246a2250`
+- Evidence: [Release Docker run 33159543959](https://github.com/rubennati/cal.diy/actions/runs/33159543959)
 - Downstream handoff: [secure-docker-blueprint issue #30](https://github.com/rubennati/secure-docker-blueprint/issues/30)
 
 Tags are architecture-specific; there is currently no combined multi-architecture manifest.


### PR DESCRIPTION
The v6.2.0-6 transparency pass updated `FORK_STATUS.md`, both ledgers, `.ai/state.md`, `.ai/sync-log.md` and `SECURITY_REVIEW.md` — but missed the two places a reader hits first.

## What was stale

| File | Claim |
| --- | --- |
| `README.md` | "Latest release: `v6.2.0-5` from `201b016984`" plus a Releases block with v6.2.0-5 digests and the old workflow run |
| `FORK_DIVERGENCE.md` | Current Basis: "Latest published fork release \| `v6.2.0-5`" and the published baseline |

The README badge already showed `v6.2.0-6` because it is generated; the prose beside it did not. That mismatch is the most visible possible form of the drift these records exist to prevent.

## What is deliberately unchanged

Historical references stay as they are, because they are accurate statements about the past:

- `Released by v6.2.0-5` rows in the divergence register
- ledger entries recording which release contained a change
- `.ai/sync-log.md` history
- `docs/SELF_HOST_PRODUCTIZATION.md` and `docs/SELF_HOST_CAPABILITY_AUDIT.md`, which describe a point-in-time audit finding

I checked every `v6.2.0-5` occurrence across the repository rather than only the two I was shown; these two were the only ones asserting it as current.

Documentation only — expected to take the `forte-ci` markdown fast path.