### PR TITLE
ci(release): publish the artifact that was validated, without rebuilding it

### DIFF
--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -36,6 +36,13 @@ inputs:
     description: "Push the exact locally validated image"
     required: false
     default: "false"
+  allow-existing-tag:
+    description: >-
+      Permit pushing over an existing tag. True only for candidate tags, which are
+      keyed by source tree and may legitimately be re-validated. Final vX.Y.Z-N
+      tags must never set this — they are immutable release identities.
+    required: false
+    default: "false"
 
 outputs:
   image_ref:
@@ -241,7 +248,7 @@ runs:
         password: ${{ inputs.github-token }}
 
     - name: Refuse to overwrite an existing release tag
-      if: ${{ inputs.push-image == 'true' }}
+      if: ${{ inputs.push-image == 'true' && inputs.allow-existing-tag != 'true' }}
       shell: bash
       env:
         IMAGE_REF: ${{ steps.image.outputs.image_ref }}

--- a/.github/workflows/forte-ci.yml
+++ b/.github/workflows/forte-ci.yml
@@ -4,9 +4,18 @@ name: forte-ci
 # (the pristine upstream mirror). Additive: upstream has no forte-* workflows.
 #
 # `ci` is the required status context on `develop` and `release`. It therefore
-# always runs and always resolves — the fast path skips expensive *steps*, never
+# always runs and always resolves — the fast paths skip expensive *steps*, never
 # the job or the workflow. A workflow-level `paths:` filter would leave the
 # required context permanently pending and block the PR instead of speeding it up.
+#
+# Three modes:
+#   full            everything runs. Every push to `develop`, and every PR that
+#                   touches a non-markdown path outside a promotion.
+#   fast            markdown-only pull request.
+#   tree-validated  promotion into/onto `release` whose tree already has a green
+#                   full-path run on `develop`. Skipping here is not a weaker
+#                   guarantee — the same tree was validated, and the mode is only
+#                   entered after proving that run exists.
 
 on:
   pull_request:
@@ -39,11 +48,57 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
+          REPO="${{ github.repository }}"
 
-          # Push events always take the full path. Release publication requires
-          # successful push-event runs for an exact branch SHA, and that evidence
-          # must not depend on which files a particular commit happened to touch.
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          # Does this exact source tree already have authoritative full-path
+          # validation on `develop`? Promotion to `release` re-creates the approved
+          # tree under a new commit SHA, so the tree — not the SHA — is what says
+          # "this source was already validated". Only a run whose `Type check` step
+          # actually executed counts; a markdown fast-path run is not evidence.
+          tree_already_validated() {
+            local want; want="$(git rev-parse HEAD^{tree} 2>/dev/null)" || return 1
+            [[ -n "$want" ]] || return 1
+            local runs
+            runs="$(gh api "repos/$REPO/actions/workflows/forte-ci.yml/runs?branch=develop&event=push&status=success&per_page=30" \
+                    --jq '.workflow_runs[] | "\(.id) \(.head_sha)"' 2>/dev/null)" || return 1
+            while read -r run_id sha; do
+              [[ -n "${sha:-}" ]] || continue
+              local t
+              t="$(gh api "repos/$REPO/commits/$sha" --jq '.commit.tree.sha' 2>/dev/null)" || continue
+              [[ "$t" == "$want" ]] || continue
+              local tc
+              tc="$(gh api "repos/$REPO/actions/runs/$run_id/jobs" \
+                    --jq '.jobs[] | select(.name=="ci") | .steps[] | select(.name=="Type check") | .conclusion' 2>/dev/null)"
+              if [[ "$tc" == "success" ]]; then
+                echo "Tree $want was fully validated by run $run_id ($sha)."
+                EVIDENCE_RUN="$run_id"; return 0
+              fi
+            done <<< "$runs"
+            return 1
+          }
+
+          EVENT="${{ github.event_name }}"
+          BASE="${{ github.base_ref }}"
+
+          # A promotion carries an already-validated tree under a new commit. Both
+          # the promotion PR into `release` and the resulting push to `release` may
+          # therefore skip the expensive source validation — but ONLY after proving
+          # the evidence exists. If it does not, this falls through to full
+          # validation rather than trusting the branch name.
+          if [[ ( "$EVENT" == "pull_request" && "$BASE" == "release" ) || ( "$EVENT" == "push" && "$GITHUB_REF" == "refs/heads/release" ) ]]; then
+            if tree_already_validated; then
+              echo "mode=tree-validated" >> "$GITHUB_OUTPUT"
+              echo "evidence_run=$EVIDENCE_RUN" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::notice::No full-path validation found for this tree -> full validation (fail-safe)."
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Every other push — notably every push to `develop` — takes the full
+          # path unconditionally. That is what produces the evidence above.
+          if [[ "$EVENT" != "pull_request" ]]; then
             echo "mode=full" >> "$GITHUB_OUTPUT"
             echo "Push event -> full validation."
             exit 0
@@ -179,9 +234,25 @@ jobs:
 
       - name: Result
         shell: bash
+        env:
+          MODE: ${{ steps.scope.outputs.mode }}
+          EVIDENCE_RUN: ${{ steps.scope.outputs.evidence_run }}
         run: |
-          if [[ "${{ steps.scope.outputs.mode }}" == "fast" ]]; then
-            echo "Markdown-only change: fork guards and whitespace check passed; install, type-check and lint intentionally skipped. This run is not evidence that the tree type-checks." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Full validation completed." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          case "$MODE" in
+            fast)
+              echo "Markdown-only change: fork guards and whitespace check passed; install, type-check and lint intentionally skipped. This run is not evidence that the tree type-checks." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            tree-validated)
+              {
+                echo "Promotion of an already-validated tree."
+                echo
+                echo "Fork guards and the whitespace check passed. Install, type-check and lint were"
+                echo "skipped because this exact source tree was fully validated by"
+                echo "[run $EVIDENCE_RUN]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$EVIDENCE_RUN)"
+                echo "on \`develop\`. This run asserts that evidence exists; it does not re-derive it."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "Full validation completed." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+          esac

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,5 +1,23 @@
 name: "Release Docker"
 
+# Artifact-promotion release pipeline.
+#
+# The image that is published is the image that was tested. Application images
+# are built EXACTLY ONCE, during candidate validation on `develop`. Tagging does
+# not rebuild them — it promotes the already-validated immutable digests to the
+# final version tags with `docker buildx imagetools create`.
+#
+# The hand-off identity between validation and publication is the **digest**
+# recorded in a `candidate-record-<tree>` artifact, never a mutable tag. The
+# candidate tags that exist in the registry are garbage-collection handles, and
+# the promote job resolves each recorded digest independently before using it.
+#
+# Candidate evidence is keyed by the source **tree**, not the commit SHA,
+# because promotion to `release` deliberately creates a new merge commit whose
+# tree is byte-identical to the approved `develop` candidate. The tree is
+# therefore the thing that proves "this is the same source"; the commit SHA is
+# not, and cannot be.
+
 on:
   push:
     tags:
@@ -31,6 +49,12 @@ jobs:
       checkout_ref: ${{ steps.identity.outputs.checkout_ref }}
       image_tag: ${{ steps.identity.outputs.image_tag }}
       source_sha: ${{ steps.identity.outputs.source_sha }}
+      source_tree: ${{ steps.identity.outputs.source_tree }}
+      candidate_run_id: ${{ steps.evidence.outputs.candidate_run_id }}
+      candidate_amd64_digest: ${{ steps.evidence.outputs.amd64_digest }}
+      candidate_arm64_digest: ${{ steps.evidence.outputs.arm64_digest }}
+      candidate_amd64_ref: ${{ steps.evidence.outputs.amd64_ref }}
+      candidate_arm64_ref: ${{ steps.evidence.outputs.arm64_ref }}
     steps:
       - name: Checkout requested source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -38,7 +62,7 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Validate release tag or prepare validation identity
+      - name: Validate release tag or prepare candidate identity
         id: identity
         shell: bash
         run: |
@@ -77,17 +101,24 @@ jobs:
             echo "checkout_ref=refs/tags/$tag" >> "$GITHUB_OUTPUT"
             echo "image_tag=$tag" >> "$GITHUB_OUTPUT"
             echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-            echo "Validated release tag $tag at $source_sha" >> "$GITHUB_STEP_SUMMARY"
+            echo "source_tree=$release_tree" >> "$GITHUB_OUTPUT"
+            echo "Validated release tag $tag at $source_sha (tree $release_tree)" >> "$GITHUB_STEP_SUMMARY"
           else
             source_sha="$(git rev-parse HEAD)"
-            branch="${GITHUB_REF#refs/heads/}"
-            sanitized_branch="$(printf '%s' "$branch" | sed 's/[^a-zA-Z0-9_.-]/-/g' | sed 's/^[-.]*//')"
-            image_tag="validation-${sanitized_branch}-${source_sha:0:10}"
-
+            source_tree="$(git rev-parse HEAD^{tree})"
             echo "checkout_ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
-            echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+            echo "image_tag=candidate-${source_tree:0:12}" >> "$GITHUB_OUTPUT"
             echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-            echo "Manual dispatch is validation-only; no image will be published." >> "$GITHUB_STEP_SUMMARY"
+            echo "source_tree=$source_tree" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Candidate validation"
+              echo
+              echo "- source: \`$source_sha\`"
+              echo "- tree: \`$source_tree\`"
+              echo "- candidate images: \`$IMAGE_NAME:candidate-${source_tree:0:12}-amd64\` / \`-arm64\`"
+              echo
+              echo "No release tag is published by this run."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Require successful release gates for exact source SHA
@@ -109,6 +140,69 @@ jobs:
             fi
           done
 
+      # Publication depends on validation evidence for THIS EXACT TREE. Without a
+      # matching candidate record there is nothing validated to promote, and the
+      # release stops here rather than falling back to building something new.
+      - name: Resolve validated candidate artifacts for this tree
+        id: evidence
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_TREE: ${{ steps.identity.outputs.source_tree }}
+          SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+
+          name="candidate-record-$SOURCE_TREE"
+          artifact="$(gh api -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/actions/artifacts?name=$name&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last')"
+
+          if [[ -z "$artifact" || "$artifact" == "null" ]]; then
+            echo "::error::No unexpired $name artifact. Run the candidate validation dispatch on develop for tree $SOURCE_TREE before tagging."
+            exit 1
+          fi
+
+          artifact_id="$(jq -r '.id' <<< "$artifact")"
+          run_id="$(jq -r '.workflow_run.id' <<< "$artifact")"
+
+          gh api "/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" > record.zip
+          unzip -p record.zip candidate-record.json > candidate-record.json
+          cat candidate-record.json
+
+          record_tree="$(jq -r '.source_tree' candidate-record.json)"
+          if [[ "$record_tree" != "$SOURCE_TREE" ]]; then
+            echo "::error::Candidate record tree $record_tree does not match release tree $SOURCE_TREE"
+            exit 1
+          fi
+
+          amd64_digest="$(jq -r '.amd64.digest' candidate-record.json)"
+          arm64_digest="$(jq -r '.arm64.digest' candidate-record.json)"
+          for d in "$amd64_digest" "$arm64_digest"; do
+            if [[ ! "$d" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "::error::Malformed digest in candidate record: $d"
+              exit 1
+            fi
+          done
+
+          {
+            echo "candidate_run_id=$run_id"
+            echo "amd64_digest=$amd64_digest"
+            echo "arm64_digest=$arm64_digest"
+            echo "amd64_ref=$(jq -r '.amd64.image' candidate-record.json)"
+            echo "arm64_ref=$(jq -r '.arm64.image' candidate-record.json)"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Promoting validated candidate artifacts"
+            echo
+            echo "- candidate validation run: [$run_id]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$run_id)"
+            echo "- AMD64 digest: \`$amd64_digest\`"
+            echo "- ARM64 digest: \`$arm64_digest\`"
+            echo
+            echo "No application image is built by this run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   validate-amd64:
     name: "Validate AMD64"
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -116,29 +210,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.image.outputs.image_ref }}
+      digest: ${{ steps.image.outputs.digest }}
     steps:
       - name: Checkout validated source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
-      - name: Build, test, and scan without publishing
+      # The only application image build in the whole release path. It is pushed
+      # so that publication can promote this exact digest instead of rebuilding.
+      - name: Build, test, scan, and publish the candidate AMD64 image
         id: image
         uses: ./.github/actions/docker-build-and-test
         with:
           platform: "linux/amd64"
-          platform-suffix: ""
+          platform-suffix: "-amd64"
           image-tag: ${{ needs.prepare.outputs.image_tag }}
+          image-version: ${{ needs.prepare.outputs.image_tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
           postgres-db: ${{ env.POSTGRES_DB }}
           database-host: ${{ env.DATABASE_HOST }}
-          push-image: "false"
+          push-image: "true"
+          allow-existing-tag: "true"
 
       - name: Upload AMD64 SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: validation-sbom-amd64-${{ needs.prepare.outputs.source_sha }}
+          name: candidate-sbom-amd64-${{ needs.prepare.outputs.source_tree }}
           path: ${{ steps.image.outputs.sbom_path }}
           if-no-files-found: error
 
@@ -149,56 +252,23 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.image.outputs.image_ref }}
+      digest: ${{ steps.image.outputs.digest }}
     steps:
       - name: Checkout validated source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
-      - name: Build, test, and scan without publishing
+      - name: Build, test, scan, and publish the candidate ARM64 image
         id: image
         uses: ./.github/actions/docker-build-and-test
         with:
           platform: "linux/arm64"
-          platform-suffix: "-arm"
+          platform-suffix: "-arm64"
           image-tag: ${{ needs.prepare.outputs.image_tag }}
-          postgres-user: ${{ env.POSTGRES_USER }}
-          postgres-password: ${{ env.POSTGRES_PASSWORD }}
-          postgres-db: ${{ env.POSTGRES_DB }}
-          database-host: ${{ env.DATABASE_HOST }}
-          push-image: "false"
-
-      - name: Upload ARM64 SBOM
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: validation-sbom-arm64-${{ needs.prepare.outputs.source_sha }}
-          path: ${{ steps.image.outputs.sbom_path }}
-          if-no-files-found: error
-
-  release-amd64:
-    name: "Release AMD64"
-    if: ${{ github.event_name == 'push' }}
-    needs: prepare
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      image_ref: ${{ steps.image.outputs.image_ref }}
-      digest: ${{ steps.image.outputs.digest }}
-    steps:
-      - name: Checkout validated release tag
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
-
-      - name: Build, test, scan, and publish exact AMD64 image
-        id: image
-        uses: ./.github/actions/docker-build-and-test
-        with:
-          platform: "linux/amd64"
-          platform-suffix: "-amd64"
-          image-tag: staging-${{ github.run_id }}-${{ github.run_attempt }}
           image-version: ${{ needs.prepare.outputs.image_tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
@@ -206,64 +276,89 @@ jobs:
           postgres-db: ${{ env.POSTGRES_DB }}
           database-host: ${{ env.DATABASE_HOST }}
           push-image: "true"
-
-      - name: Upload AMD64 SBOM
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: release-sbom-amd64-${{ needs.prepare.outputs.image_tag }}
-          path: ${{ steps.image.outputs.sbom_path }}
-          if-no-files-found: error
-
-  release-arm64:
-    name: "Release ARM64"
-    if: ${{ github.event_name == 'push' }}
-    needs: prepare
-    runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      image_ref: ${{ steps.image.outputs.image_ref }}
-      digest: ${{ steps.image.outputs.digest }}
-    steps:
-      - name: Checkout validated release tag
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
-
-      - name: Build, test, scan, and publish exact ARM64 image
-        id: image
-        uses: ./.github/actions/docker-build-and-test
-        with:
-          platform: "linux/arm64"
-          platform-suffix: "-arm"
-          image-tag: staging-${{ github.run_id }}-${{ github.run_attempt }}
-          image-version: ${{ needs.prepare.outputs.image_tag }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          postgres-user: ${{ env.POSTGRES_USER }}
-          postgres-password: ${{ env.POSTGRES_PASSWORD }}
-          postgres-db: ${{ env.POSTGRES_DB }}
-          database-host: ${{ env.DATABASE_HOST }}
-          push-image: "true"
+          allow-existing-tag: "true"
 
       - name: Upload ARM64 SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: release-sbom-arm64-${{ needs.prepare.outputs.image_tag }}
+          name: candidate-sbom-arm64-${{ needs.prepare.outputs.source_tree }}
           path: ${{ steps.image.outputs.sbom_path }}
           if-no-files-found: error
 
-  finalize-release:
-    name: "Finalize release evidence and latest"
-    if: ${{ github.event_name == 'push' }}
-    needs: [prepare, release-amd64, release-arm64]
+  record-candidate:
+    name: "Record validated candidate digests"
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: [prepare, validate-amd64, validate-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    steps:
+      - name: Write candidate record
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          SOURCE_TREE: ${{ needs.prepare.outputs.source_tree }}
+          AMD64_REF: ${{ needs.validate-amd64.outputs.image_ref }}
+          AMD64_DIGEST: ${{ needs.validate-amd64.outputs.digest }}
+          ARM64_REF: ${{ needs.validate-arm64.outputs.image_ref }}
+          ARM64_DIGEST: ${{ needs.validate-arm64.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for d in "$AMD64_DIGEST" "$ARM64_DIGEST"; do
+            if [[ ! "$d" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "::error::Validation did not produce a usable digest: '$d'"
+              exit 1
+            fi
+          done
+
+          jq -n \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg source_tree "$SOURCE_TREE" \
+            --arg amd64_ref "$AMD64_REF" \
+            --arg amd64_digest "$AMD64_DIGEST" \
+            --arg arm64_ref "$ARM64_REF" \
+            --arg arm64_digest "$ARM64_DIGEST" \
+            --arg run "$GITHUB_RUN_ID" \
+            '{source_sha: $source_sha, source_tree: $source_tree,
+              amd64: {image: $amd64_ref, digest: $amd64_digest},
+              arm64: {image: $arm64_ref, digest: $arm64_digest},
+              validation_run: $run}' > candidate-record.json
+          cat candidate-record.json
+
+          {
+            echo "## Candidate validated"
+            echo
+            echo "Tree \`$SOURCE_TREE\` is releasable. Promotion will publish these exact digests."
+            echo
+            echo "- AMD64: \`$AMD64_REF@$AMD64_DIGEST\`"
+            echo "- ARM64: \`$ARM64_REF@$ARM64_DIGEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload candidate record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: candidate-record-${{ needs.prepare.outputs.source_tree }}
+          path: candidate-record.json
+          if-no-files-found: error
+          retention-days: 90
+
+  promote:
+    name: "Promote validated digests and publish the release"
+    if: ${{ github.event_name == 'push' }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
       packages: write
+      actions: read
       id-token: write
       attestations: write
     steps:
+      - name: Checkout release tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
+
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -274,22 +369,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Publish final architecture tags and latest
+      - name: Promote validated digests to final architecture tags
         id: publish_tags
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
-          STAGING_AMD64_REF: ${{ needs.release-amd64.outputs.image_ref }}
-          STAGING_AMD64_DIGEST: ${{ needs.release-amd64.outputs.digest }}
-          STAGING_ARM64_REF: ${{ needs.release-arm64.outputs.image_ref }}
-          STAGING_ARM64_DIGEST: ${{ needs.release-arm64.outputs.digest }}
+          CAND_AMD64_REF: ${{ needs.prepare.outputs.candidate_amd64_ref }}
+          CAND_AMD64_DIGEST: ${{ needs.prepare.outputs.candidate_amd64_digest }}
+          CAND_ARM64_REF: ${{ needs.prepare.outputs.candidate_arm64_ref }}
+          CAND_ARM64_DIGEST: ${{ needs.prepare.outputs.candidate_arm64_digest }}
         run: |
           set -euo pipefail
 
           final_amd64_ref="$IMAGE_NAME:$RELEASE_TAG"
           final_arm64_ref="$IMAGE_NAME:$RELEASE_TAG-arm"
 
-          docker buildx imagetools inspect "$STAGING_AMD64_REF@$STAGING_AMD64_DIGEST" >/dev/null
-          docker buildx imagetools inspect "$STAGING_ARM64_REF@$STAGING_ARM64_DIGEST" >/dev/null
+          # Resolve each recorded digest directly. The candidate tag is only a
+          # handle; if it had been moved, this still promotes the validated bytes.
+          docker buildx imagetools inspect "$IMAGE_NAME@$CAND_AMD64_DIGEST" >/dev/null
+          docker buildx imagetools inspect "$IMAGE_NAME@$CAND_ARM64_DIGEST" >/dev/null
 
           for final_ref in "$final_amd64_ref" "$final_arm64_ref"; do
             if docker buildx imagetools inspect "$final_ref" >/dev/null 2>&1; then
@@ -298,17 +395,11 @@ jobs:
             fi
           done
 
-          docker buildx imagetools create \
-            --tag "$final_amd64_ref" \
-            "$STAGING_AMD64_REF@$STAGING_AMD64_DIGEST"
-          docker buildx imagetools create \
-            --tag "$final_arm64_ref" \
-            "$STAGING_ARM64_REF@$STAGING_ARM64_DIGEST"
+          docker buildx imagetools create --tag "$final_amd64_ref" "$IMAGE_NAME@$CAND_AMD64_DIGEST"
+          docker buildx imagetools create --tag "$final_arm64_ref" "$IMAGE_NAME@$CAND_ARM64_DIGEST"
 
-          amd64_manifest="$(docker buildx imagetools inspect "$final_amd64_ref" --format '{{json .Manifest}}')"
-          arm64_manifest="$(docker buildx imagetools inspect "$final_arm64_ref" --format '{{json .Manifest}}')"
-          amd64_digest="$(jq -r '.digest' <<< "$amd64_manifest")"
-          arm64_digest="$(jq -r '.digest' <<< "$arm64_manifest")"
+          amd64_digest="$(docker buildx imagetools inspect "$final_amd64_ref" --format '{{json .Manifest}}' | jq -r '.digest')"
+          arm64_digest="$(docker buildx imagetools inspect "$final_arm64_ref" --format '{{json .Manifest}}' | jq -r '.digest')"
 
           if [[ ! "$amd64_digest" =~ ^sha256:[a-f0-9]{64}$ || ! "$arm64_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
             echo "::error::Unable to capture final architecture digests"
@@ -316,14 +407,15 @@ jobs:
           fi
 
           docker buildx imagetools create --tag "$IMAGE_NAME:latest" "$final_amd64_ref@$amd64_digest"
-          latest_manifest="$(docker buildx imagetools inspect "$IMAGE_NAME:latest" --format '{{json .Manifest}}')"
-          latest_digest="$(jq -r '.digest' <<< "$latest_manifest")"
+          latest_digest="$(docker buildx imagetools inspect "$IMAGE_NAME:latest" --format '{{json .Manifest}}' | jq -r '.digest')"
 
-          echo "amd64_ref=$final_amd64_ref" >> "$GITHUB_OUTPUT"
-          echo "amd64_digest=$amd64_digest" >> "$GITHUB_OUTPUT"
-          echo "arm64_ref=$final_arm64_ref" >> "$GITHUB_OUTPUT"
-          echo "arm64_digest=$arm64_digest" >> "$GITHUB_OUTPUT"
-          echo "latest_digest=$latest_digest" >> "$GITHUB_OUTPUT"
+          {
+            echo "amd64_ref=$final_amd64_ref"
+            echo "amd64_digest=$amd64_digest"
+            echo "arm64_ref=$final_arm64_ref"
+            echo "arm64_digest=$arm64_digest"
+            echo "latest_digest=$latest_digest"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Attest final AMD64 build provenance
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
@@ -339,41 +431,116 @@ jobs:
           subject-digest: ${{ steps.publish_tags.outputs.arm64_digest }}
           push-to-registry: true
 
+      - name: Download validated candidate SBOMs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: candidate-sbom-*-${{ needs.prepare.outputs.source_tree }}
+          run-id: ${{ needs.prepare.outputs.candidate_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-multiple: true
+          path: sbom
+
       - name: Write release record
         id: record
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          SOURCE_TREE: ${{ needs.prepare.outputs.source_tree }}
           AMD64_REF: ${{ steps.publish_tags.outputs.amd64_ref }}
           AMD64_DIGEST: ${{ steps.publish_tags.outputs.amd64_digest }}
           ARM64_REF: ${{ steps.publish_tags.outputs.arm64_ref }}
           ARM64_DIGEST: ${{ steps.publish_tags.outputs.arm64_digest }}
           LATEST_DIGEST: ${{ steps.publish_tags.outputs.latest_digest }}
-          STAGING_AMD64_REF: ${{ needs.release-amd64.outputs.image_ref }}
-          STAGING_ARM64_REF: ${{ needs.release-arm64.outputs.image_ref }}
+          CAND_AMD64_DIGEST: ${{ needs.prepare.outputs.candidate_amd64_digest }}
+          CAND_ARM64_DIGEST: ${{ needs.prepare.outputs.candidate_arm64_digest }}
+          CANDIDATE_RUN: ${{ needs.prepare.outputs.candidate_run_id }}
         run: |
           set -euo pipefail
           jq -n \
             --arg tag "$RELEASE_TAG" \
             --arg source_sha "$SOURCE_SHA" \
+            --arg source_tree "$SOURCE_TREE" \
             --arg amd64_ref "$AMD64_REF" \
             --arg amd64_digest "$AMD64_DIGEST" \
             --arg arm64_ref "$ARM64_REF" \
             --arg arm64_digest "$ARM64_DIGEST" \
             --arg latest_digest "$LATEST_DIGEST" \
-            --arg staging_amd64 "$STAGING_AMD64_REF" \
-            --arg staging_arm64 "$STAGING_ARM64_REF" \
+            --arg cand_amd64 "$CAND_AMD64_DIGEST" \
+            --arg cand_arm64 "$CAND_ARM64_DIGEST" \
+            --arg candidate_run "$CANDIDATE_RUN" \
             --arg workflow_run "$GITHUB_RUN_ID" \
-            '{tag: $tag, source_sha: $source_sha, amd64: {image: $amd64_ref, digest: $amd64_digest, staging_image: $staging_amd64}, arm64: {image: $arm64_ref, digest: $arm64_digest, staging_image: $staging_arm64}, latest_digest: $latest_digest, workflow_run: $workflow_run}' \
+            '{tag: $tag, source_sha: $source_sha, source_tree: $source_tree,
+              amd64: {image: $amd64_ref, digest: $amd64_digest, validated_digest: $cand_amd64},
+              arm64: {image: $arm64_ref, digest: $arm64_digest, validated_digest: $cand_arm64},
+              latest_digest: $latest_digest,
+              candidate_validation_run: $candidate_run,
+              workflow_run: $workflow_run}' \
             > release-record.json
+          cat release-record.json
+
+      # Notes are generated FROM release-record.json so the published facts cannot
+      # drift from the artifacts. Optional hand-written prose for this release is
+      # taken verbatim from docs/release-notes/<tag>.md when that file exists.
+      - name: Compose release notes from the release record
+        id: notes
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          prose="docs/release-notes/${RELEASE_TAG}.md"
+          : > release-notes.md
+          if [[ -f "$prose" ]]; then
+            cat "$prose" >> release-notes.md
+            printf '\n\n---\n\n' >> release-notes.md
+          else
+            echo "::warning::No $prose in the release tree; publishing the artifact record only."
+          fi
+
+          jq -r '
+            "## Release artifacts\n",
+            "Deploy by digest. `latest` is a convenience pointer and is not the release identity.\n",
+            "```",
+            "\(.amd64.image)@\(.amd64.digest)",
+            "\(.arm64.image)@\(.arm64.digest)",
+            "```\n",
+            "| | |",
+            "| --- | --- |",
+            "| Source commit | `\(.source_sha)` |",
+            "| Source tree | `\(.source_tree)` |",
+            "| AMD64 | `\(.amd64.image)` · `\(.amd64.digest)` |",
+            "| ARM64 | `\(.arm64.image)` · `\(.arm64.digest)` |",
+            "| `latest` | `\(.latest_digest)` (convenience only) |",
+            "| Candidate validation run | \(.candidate_validation_run) |",
+            "| Publication run | \(.workflow_run) |\n",
+            "Both images were built, runtime-tested, licence-asserted, scanned and SBOM'\''d once",
+            "during candidate validation on native runners. Publication promoted those exact",
+            "digests without rebuilding, so the published artifact is the tested artifact.\n",
+            "CycloneDX SBOMs and `release-record.json` are attached below."
+          ' release-record.json >> release-notes.md
+
+      - name: Publish the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::GitHub Release $RELEASE_TAG already exists and will not be overwritten"
+            exit 1
+          fi
+          gh release create "$RELEASE_TAG" \
+            --verify-tag \
+            --title "cal.forte $RELEASE_TAG" \
+            --notes-file release-notes.md \
+            release-record.json sbom/*.cdx.json
 
           {
-            echo "## Published release $RELEASE_TAG"
+            echo "## Published $RELEASE_TAG"
             echo
-            echo "- Source: \`$SOURCE_SHA\`"
-            echo "- AMD64: \`$AMD64_REF@$AMD64_DIGEST\`"
-            echo "- ARM64: \`$ARM64_REF@$ARM64_DIGEST\`"
-            echo "- latest (convenience only): \`$IMAGE_NAME:latest@$LATEST_DIGEST\`"
+            echo "- $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG"
+            echo "- AMD64: \`${{ steps.publish_tags.outputs.amd64_ref }}@${{ steps.publish_tags.outputs.amd64_digest }}\`"
+            echo "- ARM64: \`${{ steps.publish_tags.outputs.arm64_ref }}@${{ steps.publish_tags.outputs.arm64_digest }}\`"
+            echo "- no application image was rebuilt during publication"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release record

--- a/FORK_PROCESS.md
+++ b/FORK_PROCESS.md
@@ -68,9 +68,10 @@ every event:
 
 | Event | Fork guards + whitespace check | Install · lifecycle · `type-check:ci` · Biome |
 | --- | --- | --- |
-| any `push` to `develop` / `release` | always | always |
+| any `push` to `develop` | always | always |
 | PR touching any path that is not `*.md` | always | always |
 | PR touching *only* `*.md` files | always | skipped |
+| promotion into / push onto `release`, tree already validated | always | skipped |
 
 The classification is an **allowlist** with exactly one rule: a changed path is documentation
 only if its name ends in `.md`. Everything else — including any directory added to this
@@ -80,13 +81,18 @@ extension and not on a directory because `docs/` is **not** documentation-only: 
 `docs/brand/build.py` and the generated `docs/api-reference/v2/openapi.json`, both of which a
 `docs/**` rule would have fast-pathed.
 
-Two consequences worth stating plainly. First, a green `ci` on a documentation-only PR is
-**not** evidence that the tree type-checks — it is evidence that the fork guards hold and that
-nothing outside the allowlist changed. Second, that distinction never reaches a release,
-because `release-docker.yaml` validates successful **push**-event runs for an exact SHA, and
-push events have no fast path. Release evidence therefore never depends on which paths a
-commit happened to touch. The same reasoning governs `forte-codeql.yml`, whose `paths-ignore`
-is scoped to its `pull_request` trigger only.
+A green `ci` on a documentation-only PR is **not** evidence that the tree type-checks — it is
+evidence that the fork guards hold and that nothing outside the allowlist changed.
+
+The `release` row is a different claim and rests on a different argument. Promotion re-creates
+an already-approved `develop` tree under a new commit SHA; re-running `type-check:ci` on it
+would recompute a known answer. That row is only taken after the workflow has **proved** a
+successful full-path `forte-ci` push run exists on `develop` for this exact tree — matched by
+tree SHA, and accepted only if that run's `Type check` step actually executed rather than
+being skipped by one of these fast paths. If no such evidence is found, the run falls through
+to full validation; the branch name alone never buys the skip. `forte-codeql.yml`'s
+`paths-ignore` is scoped to its `pull_request` trigger only, so release publication still
+requires a real CodeQL push run for the exact release SHA.
 
 The four fork guards run before dependency installation because each is a plain shell script
 needing only git and coreutils. That is what makes them affordable on every event, and it also

--- a/IMAGE_BUILD.md
+++ b/IMAGE_BUILD.md
@@ -37,15 +37,27 @@ Each architecture is built once. The same local image is runtime-tested, scanned
 an SBOM, and then pushed with `docker push`; there is no second untested rebuild. The
 registry digest is read after push and exposed as a job output.
 
-The release finalizer uploads `release-record.json` containing source SHA, architecture
-image references, architecture digests, workflow run ID, and the convenience `latest`
-digest. GitHub build-provenance attestations are pushed for both architecture images.
+The release promote job uploads `release-record.json` containing source SHA, source tree,
+architecture image references, final architecture digests, the validated candidate digests
+those were promoted from, the candidate validation run, the publication run ID, and the
+convenience `latest` digest. GitHub build-provenance attestations are pushed for both final
+architecture digests, and the GitHub Release is generated from that same record.
+
+**Images are built exactly once.** The build happens during candidate validation on
+`develop`; publication promotes the recorded immutable digests with
+`docker buildx imagetools create` and rebuilds nothing. The digest published under
+`vX.Y.Z-N` is therefore byte-identical to the image that passed the runtime test, the
+`LICENSE` byte-equality assertion and the Trivy scan. Verifying a release needs no local
+Docker daemon.
 
 ## Current Security Gates
 
-- Runtime health check: blocking.
-- Existing-tag overwrite protection: blocking.
+- Runtime health check: blocking (at candidate validation, on the image that is published).
+- Root `LICENSE` byte-equality inside the image: blocking (same image).
+- Existing-tag overwrite protection on final version tags: blocking.
 - Tag/source identity validation: blocking.
+- Candidate-record presence for the exact release tree: blocking. Publication cannot
+  proceed without validation evidence for that tree, and has no build fallback.
 - `forte-ci` install/source-clean check, fork guard, and typecheck: blocking.
 - Trivy image scan: **report-only** (`exit-code: 0`) while inherited runtime findings remain.
 - Biome in `forte-ci`: report-only until inherited baseline findings are resolved.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -17,7 +17,18 @@ validation.
   `origin/release` HEAD.
 - Version tags and GHCR tags are immutable identities and must not be overwritten.
 - Manual workflow dispatch is validation-only and cannot publish.
-- `latest` is convenience metadata, updated only after both architecture jobs succeed;
+- **The published artifact is the validated artifact.** Application images are built
+  exactly once, during candidate validation. Tagging promotes those immutable digests;
+  it never rebuilds.
+- Candidate evidence is keyed by the source **tree**, not the commit SHA. Promotion
+  deliberately creates a new merge commit whose tree is identical to the approved
+  candidate, so the tree is what proves "same source" — the SHA cannot.
+- The hand-off identity between validation and publication is a **digest** recorded in a
+  `candidate-record-<tree>` artifact. Candidate image tags are garbage-collection handles
+  and are never trusted as the hand-off identity.
+- Releasing requires no local Docker daemon. Every artifact assertion happens in CI, on
+  native runners, against the exact image that is published.
+- `latest` is convenience metadata, updated only after promotion succeeds;
   downstream must never rely on it.
 
 ## 1. Prepare The Candidate On `develop`
@@ -35,8 +46,14 @@ git diff --check
 
 5. Run focused tests for changed security/runtime paths.
 6. Run `forte-ci`, CodeQL, and Trivy on `develop` and record known non-blocking findings.
-7. Run `Release Docker` manually on `develop`. This builds, runtime-tests, scans, and
-   produces SBOM artifacts for AMD64 and ARM64, but cannot publish.
+7. Run `Release Docker` manually on `develop`. **This is the only time application images
+   are built in the release path.** It builds AMD64 and ARM64 natively, runtime-tests each
+   exact image, asserts the root `LICENSE` byte-for-byte inside it, scans it, generates its
+   CycloneDX SBOM, pushes it to a tree-keyed candidate tag, and records both immutable
+   digests in a `candidate-record-<tree>` artifact. It cannot publish a release tag.
+
+   If `develop` moves after this run, the candidate record no longer matches the tree and
+   publication will refuse to proceed — re-run the dispatch on the new candidate.
 
 ## 2. Promote To `release`
 
@@ -130,23 +147,44 @@ the current `origin/release` head.
 
 ## 5. Workflow Publication
 
-For each architecture, the workflow:
+Pushing the tag runs `Release Docker` in **promotion** mode. It builds nothing.
 
-1. checks out the validated tag
-2. builds one local image
-3. runtime-tests that exact image
-4. scans that exact image with Trivy (currently report-only)
-5. generates a CycloneDX SBOM
-6. pushes the exact tested image under a unique workflow staging tag
-7. records the staging registry digest
+`prepare`:
 
-After both architecture jobs succeed, the finalizer verifies both staging digests, refuses
-to overwrite existing public version tags, creates the final AMD64 and ARM64 tags, updates
-the convenience `latest` tag to AMD64, creates provenance attestations for the final
-digests, and uploads `release-record.json`. If either architecture job fails, no public
-version tag or `latest` update occurs. GHCR tag creation itself is not transactional; if
-the finalizer fails between tag operations, the release is incomplete and all resulting
-tags must be inspected before a new build-number release is prepared.
+1. rejects a malformed or lightweight tag, or one not pointing at `origin/release` HEAD
+2. rejects a `release` tree that differs from `origin/develop`
+3. requires successful `forte-ci`, `forte-codeql` and `forte-trivy` push runs for the exact
+   release SHA
+4. locates the `candidate-record-<tree>` artifact for this exact tree and reads both
+   validated digests from it — **if no unexpired record exists for this tree, the release
+   stops here.** There is no fallback that builds something new
+
+`promote`:
+
+5. resolves each recorded digest directly in the registry, by digest, not by candidate tag
+6. refuses to overwrite an existing final version tag
+7. creates the final `vX.Y.Z-N` and `vX.Y.Z-N-arm` tags from those exact digests with
+   `docker buildx imagetools create`
+8. updates the convenience `latest` tag to the AMD64 digest
+9. attests SLSA build provenance for both final digests
+10. downloads the candidate SBOMs produced against those same images
+11. writes `release-record.json`
+12. creates the GitHub Release, generating its facts **from `release-record.json`** and
+    attaching both SBOMs and the record itself
+
+Step 12 is why release facts cannot drift between the artifacts and the announcement: the
+published table is rendered from the same JSON the pipeline emitted. Hand-written prose for
+a release is optional and lives at `docs/release-notes/vX.Y.Z-N.md` in the release tree; when
+present it is prepended verbatim, when absent the Release carries the artifact record alone.
+
+Because no image is rebuilt, the digest published under `vX.Y.Z-N` is byte-identical to the
+image that passed the runtime test, the `LICENSE` assertion and the Trivy scan during
+candidate validation. Verifying the release therefore requires no local Docker daemon —
+and the release contract does not ask for one.
+
+**Non-transactional caveat, unchanged.** GHCR tag creation is not atomic. If promotion fails
+between tag operations the release is incomplete, and all resulting tags must be inspected
+before preparing a new build-number release.
 
 ## 6. Release Record And Downstream Handoff
 

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -106,11 +106,12 @@ as merge or publication blockers.
 Do not read any of the above as: all security issues are fixed, all CRITICAL scanner
 findings are closed, Teams are secure, or PBAC is implemented. None of those are true.
 
-**One process gap, recorded rather than quietly closed.** `release-docker.yaml` does not
-create the GitHub Release object; `v6.2.0-6` is the first tag in this repository to have
-one, and it was created manually after publication. The release contracts do not yet
-describe that step, so it is currently outside the automated pipeline and outside the
-evidence the pipeline itself produces.
+**One process gap, now closed.** For `v6.2.0-6` the GitHub Release object was created
+manually after publication: `release-docker.yaml` did not produce one and no release
+contract described the step. The artifact-promotion pipeline moves Release creation into
+the workflow and generates its facts from `release-record.json`, so the published
+announcement and the artifacts cannot disagree. `v6.2.0-6` remains the one release whose
+Release object was authored by hand.
 
 ## Incident-Oriented Checks
 

--- a/agents/rules/ci-check-failures.md
+++ b/agents/rules/ci-check-failures.md
@@ -18,13 +18,16 @@ Only fork-owned workflows run — the upstream workflows are disabled on `main`
   **Security → Code scanning** and do not block merges
 - **`release-docker`** — builds and publishes the GHCR image on `v*` tags only
 
-`forte-ci` takes a fast path on pull requests whose changed files are *all* `*.md`: the guards
-and whitespace check still run, install/type-check/Biome do not. Every push, and every PR
-touching any non-markdown path, takes the full path — including `docs/brand/build.py` and
-`docs/api-reference/v2/openapi.json`, which live under `docs/` but are not documentation. So on a documentation-only PR,
-a green `ci` does not tell you the tree type-checks — run `yarn type-check:ci --force` locally
-if you need that. See [FORK_PROCESS.md](../../FORK_PROCESS.md) → *Branch Contract and Required
-Checks*.
+`forte-ci` has three modes. **Full** is the default and covers every push to `develop` and
+every PR touching a non-markdown path. **Fast** applies to PRs whose changed files are all
+`*.md` — guards and the whitespace check still run, install/type-check/Biome do not; note
+that `docs/brand/build.py` and `docs/api-reference/v2/openapi.json` live under `docs/` but
+are not markdown and so take the full path. **Tree-validated** applies to release promotion,
+and only after the workflow proves a green full-path run exists on `develop` for this exact
+source tree.
+
+So a green `ci` on a markdown PR does not tell you the tree type-checks — run
+`yarn type-check:ci --force` locally if you need that. See [FORK_PROCESS.md](../../FORK_PROCESS.md) → *Branch Contract and Required Checks*.
 
 ## What to focus on
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,16 @@
+# Release notes prose
+
+Optional hand-written prose for a release, one file per tag: `vX.Y.Z-N.md`.
+
+`Release Docker`'s promote job prepends this file verbatim to the GitHub Release body and
+then appends an artifact table it generates from `release-record.json`. When no file exists
+for a tag, the Release carries the generated artifact record alone and the workflow emits a
+notice.
+
+Keep the facts out of here. Digests, refs, source SHA, source tree and workflow run IDs are
+rendered from `release-record.json` so the announcement cannot drift from the artifacts —
+restating them by hand reintroduces exactly the drift that generation prevents.
+
+Write what the artifact record cannot say: why the release matters, which attack paths it
+closes, what it deliberately does **not** claim, and what an operator must know before
+upgrading.


### PR DESCRIPTION
The release path built every application image **twice**. Candidate validation on `develop` built AMD64 and ARM64, runtime-tested them, asserted the `LICENSE`, scanned them and generated SBOMs — then the tag push did all of it again over the same source, and only the second build's output was ever published.

So the artifact that shipped was never the artifact that was validated. It was a different build of the same source, assumed equivalent.

## Measured cost of the duplication (v6.2.0-6, real numbers)

| Run | Wall | Job-seconds |
| --- | --- | --- |
| `Release Docker` VALIDATE (candidate) | 1056s | 1908s |
| `Release Docker` PUBLISH (tag) | 1327s | 2333s |

The publish run's 2,333 job-seconds were spent re-deriving a result the validate run already had.

## Before / after, serialized critical path

| Phase | Before | After | Δ |
| --- | --- | --- | --- |
| candidate push gates (parallel) | 478s | 478s | — |
| candidate `Release Docker` (build once, now also pushes) | 1056s | ~1300s | +244s |
| promotion PR `ci` | 499s | ~15s | **−484s** |
| release push gates (parallel) | 437s | 262s | −175s |
| tag `Release Docker` (was: second build) | 1327s | ~150s | **−1177s** |
| **total** | **3797s ≈ 63 min** | **~2205s ≈ 37 min** | **≈ −26 min (−42%)** |

### Removed vs merely moved

**Genuinely removed** — work that no longer happens anywhere:

- the second AMD64 build/test/scan/SBOM (1261s of job time)
- the second ARM64 build/test/scan/SBOM (1017s of job time)
- full source validation on the promotion PR (499s → 15s)
- full source validation on the release push (437s → 15s)

**Moved, not removed:**

- the registry push moves from publication into candidate validation (+~244s there)
- GitHub Release creation moves from a manual post-hoc step into the workflow (+~10s)

**Deliberately kept:** `forte-codeql` and `forte-trivy` still run in full on the release push. They are security scans, and removing them to save 262s would weaken the release gate for no structural reason. That is now the critical path of that phase — an honest consequence, not an oversight.

## How it works

**Build once, promote digests.** Images are built only during candidate validation and pushed to a candidate tag. Publication promotes the recorded digests to the final version tags with `docker buildx imagetools create` and builds nothing. The digest published under `vX.Y.Z-N` is byte-identical to the image that passed the runtime test, the `LICENSE` assertion and the Trivy scan.

**Keyed by tree, not SHA.** Promotion deliberately creates a new merge commit whose tree is identical to the approved candidate — so the commit SHA *cannot* express "same source" and the tree can. Candidate evidence is therefore stored as `candidate-record-<tree>`.

**The hand-off identity is a digest, never a tag.** Candidate tags are garbage-collection handles. `promote` reads digests from the record and resolves each one directly (`imagetools inspect $IMAGE@$DIGEST`), so a moved candidate tag cannot redirect a release.

**No build fallback.** If no unexpired candidate record exists for the release tree, publication stops. Inventing an artifact at that point would defeat the whole chain.

## `forte-ci` gains a third mode

| Mode | When | Expensive steps |
| --- | --- | --- |
| `full` | every push to `develop`; any PR touching a non-markdown path | run |
| `fast` | markdown-only PR | skipped |
| `tree-validated` | promotion into/onto `release` | skipped |

`tree-validated` is entered **only after proving** a green full-path `forte-ci` push run exists on `develop` for this exact tree — matched by tree SHA, and accepted only if that run's `Type check` step actually executed. A markdown fast-path run is explicitly not evidence. Absent proof it falls through to `full`; the branch name alone never buys the skip.

I tested this against the real v6.2.0-6 data rather than only writing it:

```
target tree 8db16d911d…  ->  MATCH run=33156410816 sha=889b7cc6ce TypeCheck=success
known fast-path run 33155566614  ->  TypeCheck=skipped  ->  rejected
```

Both directions behave correctly.

## GitHub Release becomes part of the pipeline

`promote` creates the Release and renders its facts **from `release-record.json`**, so the announcement cannot drift from the artifacts. Optional prose lives at `docs/release-notes/<tag>.md` and is prepended verbatim; the convention is documented, including the rule that facts must *not* be restated there. Both SBOMs and the record are attached.

This closes the gap recorded in `SECURITY_REVIEW.md` during the v6.2.0-6 release. That release's Release object stays the only hand-authored one.

## Preserved

Protected branches · required `ci` · immutable annotated tags · release tree identity · no squash/rebase promotion · native AMD64 and native ARM64 · runtime smoke test · `LICENSE` byte-equality · Trivy · CycloneDX SBOMs · SLSA provenance on the final digests · non-overwrite of final version tags · `release-record.json`.

`allow-existing-tag` is new on the build action and is set **only** for candidate tags, which are tree-keyed and may legitimately be re-validated. Final `vX.Y.Z-N` tags never set it.

## Not done here

No release is performed by this PR. The first release to exercise the new path will be the next one; until then `Release Docker` on a tag would still find no candidate record and refuse — which is the intended failure, not a regression.