### PR TITLE
ci(release): make the promotion evidence chain describe what actually happened

### DIFF
--- a/.github/actions/docker-build-and-test/action.yml
+++ b/.github/actions/docker-build-and-test/action.yml
@@ -16,6 +16,13 @@ inputs:
     description: "Public source version stored in OCI labels"
     required: false
     default: ""
+  image-revision:
+    description: >-
+      Commit recorded in org.opencontainers.image.revision. Defaults to github.sha,
+      which for a workflow_dispatch is the branch head at dispatch time — pass the
+      pinned candidate SHA so the label describes the commit actually built.
+    required: false
+    default: ""
   github-token:
     description: "GitHub token used only when push-image is true"
     required: false
@@ -126,7 +133,7 @@ runs:
         tags: ${{ steps.image.outputs.image_ref }}
         labels: |
           org.opencontainers.image.source=https://github.com/${{ github.repository }}
-          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.revision=${{ inputs.image-revision || github.sha }}
           org.opencontainers.image.version=${{ inputs.image-version || inputs.image-tag }}
         build-args: |
           NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000

--- a/.github/workflows/forte-ci.yml
+++ b/.github/workflows/forte-ci.yml
@@ -178,6 +178,12 @@ jobs:
         # Temporary — retire when PBAC is actually implemented. See #13.
         run: bash scripts/fork-guard-pbac-fail-closed.sh
 
+      - name: Release promotion state machine
+        # Blocking on purpose: the promote job publishes immutable version tags and
+        # cannot be rehearsed. This asserts its recovery behaviour, and fails if the
+        # harness has drifted from the logic the workflow actually ships.
+        run: bash scripts/release-promotion-reconcile.test.sh
+
       - name: Whitespace and conflict-marker check
         shell: bash
         # Says what it compared. A clean `git diff --check` prints nothing, so

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -55,6 +55,7 @@ jobs:
       candidate_arm64_digest: ${{ steps.evidence.outputs.arm64_digest }}
       candidate_amd64_ref: ${{ steps.evidence.outputs.amd64_ref }}
       candidate_arm64_ref: ${{ steps.evidence.outputs.arm64_ref }}
+      candidate_sha: ${{ steps.evidence.outputs.candidate_sha }}
     steps:
       - name: Checkout requested source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -106,7 +107,11 @@ jobs:
           else
             source_sha="$(git rev-parse HEAD)"
             source_tree="$(git rev-parse HEAD^{tree})"
-            echo "checkout_ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+            # Pin to the resolved commit, never to the branch ref. `develop` may
+            # move between this job and the build jobs, and a moving ref would let
+            # them build a tree other than the one recorded here — the images and
+            # the candidate record would then describe different sources.
+            echo "checkout_ref=$source_sha" >> "$GITHUB_OUTPUT"
             echo "image_tag=candidate-${source_tree:0:12}" >> "$GITHUB_OUTPUT"
             echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
             echo "source_tree=$source_tree" >> "$GITHUB_OUTPUT"
@@ -191,6 +196,7 @@ jobs:
             echo "arm64_digest=$arm64_digest"
             echo "amd64_ref=$(jq -r '.amd64.image' candidate-record.json)"
             echo "arm64_ref=$(jq -r '.arm64.image' candidate-record.json)"
+            echo "candidate_sha=$(jq -r '.source_sha' candidate-record.json)"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -211,6 +217,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     outputs:
       image_ref: ${{ steps.image.outputs.image_ref }}
       digest: ${{ steps.image.outputs.digest }}
@@ -219,6 +227,21 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
+
+      - name: Assert the checked-out source is the recorded candidate
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+          EXPECTED_TREE: ${{ needs.prepare.outputs.source_tree }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          actual_tree="$(git rev-parse HEAD^{tree})"
+          echo "commit $actual_sha / tree $actual_tree"
+          if [[ "$actual_sha" != "$EXPECTED_SHA" || "$actual_tree" != "$EXPECTED_TREE" ]]; then
+            echo "::error::Checked out $actual_sha ($actual_tree), expected $EXPECTED_SHA ($EXPECTED_TREE)"
+            exit 1
+          fi
 
       # The only application image build in the whole release path. It is pushed
       # so that publication can promote this exact digest instead of rebuilding.
@@ -230,6 +253,7 @@ jobs:
           platform-suffix: "-amd64"
           image-tag: ${{ needs.prepare.outputs.image_tag }}
           image-version: ${{ needs.prepare.outputs.image_tag }}
+          image-revision: ${{ needs.prepare.outputs.source_sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
@@ -237,6 +261,15 @@ jobs:
           database-host: ${{ env.DATABASE_HOST }}
           push-image: "true"
           allow-existing-tag: "true"
+
+      # Provenance is generated HERE, by the job that actually built the image.
+      # Attesting during promotion would claim the promoting workflow built it.
+      - name: Attest AMD64 build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
 
       - name: Upload AMD64 SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -253,6 +286,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     outputs:
       image_ref: ${{ steps.image.outputs.image_ref }}
       digest: ${{ steps.image.outputs.digest }}
@@ -262,6 +297,21 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.checkout_ref }}
 
+      - name: Assert the checked-out source is the recorded candidate
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
+          EXPECTED_TREE: ${{ needs.prepare.outputs.source_tree }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          actual_tree="$(git rev-parse HEAD^{tree})"
+          echo "commit $actual_sha / tree $actual_tree"
+          if [[ "$actual_sha" != "$EXPECTED_SHA" || "$actual_tree" != "$EXPECTED_TREE" ]]; then
+            echo "::error::Checked out $actual_sha ($actual_tree), expected $EXPECTED_SHA ($EXPECTED_TREE)"
+            exit 1
+          fi
+
       - name: Build, test, scan, and publish the candidate ARM64 image
         id: image
         uses: ./.github/actions/docker-build-and-test
@@ -270,6 +320,7 @@ jobs:
           platform-suffix: "-arm64"
           image-tag: ${{ needs.prepare.outputs.image_tag }}
           image-version: ${{ needs.prepare.outputs.image_tag }}
+          image-revision: ${{ needs.prepare.outputs.source_sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           postgres-user: ${{ env.POSTGRES_USER }}
           postgres-password: ${{ env.POSTGRES_PASSWORD }}
@@ -277,6 +328,15 @@ jobs:
           database-host: ${{ env.DATABASE_HOST }}
           push-image: "true"
           allow-existing-tag: "true"
+
+      # Provenance is generated HERE, by the job that actually built the image.
+      # Attesting during promotion would claim the promoting workflow built it.
+      - name: Attest ARM64 build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
 
       - name: Upload ARM64 SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -351,8 +411,6 @@ jobs:
       contents: write
       packages: write
       actions: read
-      id-token: write
-      attestations: write
     steps:
       - name: Checkout release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -369,67 +427,84 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
+      # Fail closed on missing provenance: a digest with no attestation is not
+      # evidence of anything, and promotion is the last point at which that can
+      # still be caught cheaply.
+      - name: Require build provenance for the candidate digests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CAND_AMD64_DIGEST: ${{ needs.prepare.outputs.candidate_amd64_digest }}
+          CAND_ARM64_DIGEST: ${{ needs.prepare.outputs.candidate_arm64_digest }}
+        run: |
+          set -euo pipefail
+          for d in "$CAND_AMD64_DIGEST" "$CAND_ARM64_DIGEST"; do
+            if ! gh attestation verify "oci://$IMAGE_NAME@$d" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "::error::No verifiable build provenance for $IMAGE_NAME@$d"
+              exit 1
+            fi
+            echo "provenance verified for $d"
+          done
+
+      # Idempotent by construction, so a transient failure part-way through does
+      # not strand the release behind an immutable tag it already created:
+      #   absent          -> create from the expected candidate digest
+      #   present, equal  -> already done, continue
+      #   present, other  -> fail hard; never redirect a published version tag
       - name: Promote validated digests to final architecture tags
         id: publish_tags
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
-          CAND_AMD64_REF: ${{ needs.prepare.outputs.candidate_amd64_ref }}
           CAND_AMD64_DIGEST: ${{ needs.prepare.outputs.candidate_amd64_digest }}
-          CAND_ARM64_REF: ${{ needs.prepare.outputs.candidate_arm64_ref }}
           CAND_ARM64_DIGEST: ${{ needs.prepare.outputs.candidate_arm64_digest }}
         run: |
           set -euo pipefail
 
-          final_amd64_ref="$IMAGE_NAME:$RELEASE_TAG"
-          final_arm64_ref="$IMAGE_NAME:$RELEASE_TAG-arm"
+          digest_of() { docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' 2>/dev/null | jq -r '.digest // empty'; }
 
-          # Resolve each recorded digest directly. The candidate tag is only a
-          # handle; if it had been moved, this still promotes the validated bytes.
+          reconcile() {
+            local ref="$1" want="$2" have
+            have="$(digest_of "$ref")"
+            if [[ -z "$have" ]]; then
+              docker buildx imagetools create --tag "$ref" "$IMAGE_NAME@$want"
+              have="$(digest_of "$ref")"
+              if [[ "$have" != "$want" ]]; then
+                echo "::error::$ref resolved to $have after creation, expected $want"
+                exit 1
+              fi
+              echo "created  $ref -> $have"
+            elif [[ "$have" == "$want" ]]; then
+              echo "existing $ref already resolves to $have; nothing to do"
+            else
+              echo "::error::$ref already exists and points to $have, not the validated $want."
+              echo "::error::A published version tag is immutable and will not be redirected."
+              exit 1
+            fi
+          }
+
+          # Both candidate digests must resolve before anything is published.
           docker buildx imagetools inspect "$IMAGE_NAME@$CAND_AMD64_DIGEST" >/dev/null
           docker buildx imagetools inspect "$IMAGE_NAME@$CAND_ARM64_DIGEST" >/dev/null
 
-          for final_ref in "$final_amd64_ref" "$final_arm64_ref"; do
-            if docker buildx imagetools inspect "$final_ref" >/dev/null 2>&1; then
-              echo "::error::Final release tag already exists and will not be overwritten: $final_ref"
-              exit 1
-            fi
-          done
+          final_amd64_ref="$IMAGE_NAME:$RELEASE_TAG"
+          final_arm64_ref="$IMAGE_NAME:$RELEASE_TAG-arm"
+          reconcile "$final_amd64_ref" "$CAND_AMD64_DIGEST"
+          reconcile "$final_arm64_ref" "$CAND_ARM64_DIGEST"
 
-          docker buildx imagetools create --tag "$final_amd64_ref" "$IMAGE_NAME@$CAND_AMD64_DIGEST"
-          docker buildx imagetools create --tag "$final_arm64_ref" "$IMAGE_NAME@$CAND_ARM64_DIGEST"
-
-          amd64_digest="$(docker buildx imagetools inspect "$final_amd64_ref" --format '{{json .Manifest}}' | jq -r '.digest')"
-          arm64_digest="$(docker buildx imagetools inspect "$final_arm64_ref" --format '{{json .Manifest}}' | jq -r '.digest')"
-
-          if [[ ! "$amd64_digest" =~ ^sha256:[a-f0-9]{64}$ || ! "$arm64_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-            echo "::error::Unable to capture final architecture digests"
-            exit 1
+          # `latest` is a mutable convenience pointer, so moving it onto the
+          # release AMD64 digest is idempotent and safe to repeat.
+          latest_have="$(digest_of "$IMAGE_NAME:latest")"
+          if [[ "$latest_have" != "$CAND_AMD64_DIGEST" ]]; then
+            docker buildx imagetools create --tag "$IMAGE_NAME:latest" "$IMAGE_NAME@$CAND_AMD64_DIGEST"
           fi
-
-          docker buildx imagetools create --tag "$IMAGE_NAME:latest" "$final_amd64_ref@$amd64_digest"
-          latest_digest="$(docker buildx imagetools inspect "$IMAGE_NAME:latest" --format '{{json .Manifest}}' | jq -r '.digest')"
+          latest_digest="$(digest_of "$IMAGE_NAME:latest")"
 
           {
             echo "amd64_ref=$final_amd64_ref"
-            echo "amd64_digest=$amd64_digest"
+            echo "amd64_digest=$CAND_AMD64_DIGEST"
             echo "arm64_ref=$final_arm64_ref"
-            echo "arm64_digest=$arm64_digest"
+            echo "arm64_digest=$CAND_ARM64_DIGEST"
             echo "latest_digest=$latest_digest"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Attest final AMD64 build provenance
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
-        with:
-          subject-name: ${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.publish_tags.outputs.amd64_digest }}
-          push-to-registry: true
-
-      - name: Attest final ARM64 build provenance
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
-        with:
-          subject-name: ${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.publish_tags.outputs.arm64_digest }}
-          push-to-registry: true
 
       - name: Download validated candidate SBOMs
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -454,12 +529,14 @@ jobs:
           CAND_AMD64_DIGEST: ${{ needs.prepare.outputs.candidate_amd64_digest }}
           CAND_ARM64_DIGEST: ${{ needs.prepare.outputs.candidate_arm64_digest }}
           CANDIDATE_RUN: ${{ needs.prepare.outputs.candidate_run_id }}
+          CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
         run: |
           set -euo pipefail
           jq -n \
             --arg tag "$RELEASE_TAG" \
-            --arg source_sha "$SOURCE_SHA" \
-            --arg source_tree "$SOURCE_TREE" \
+            --arg release_sha "$SOURCE_SHA" \
+            --arg release_tree "$SOURCE_TREE" \
+            --arg candidate_sha "$CANDIDATE_SHA" \
             --arg amd64_ref "$AMD64_REF" \
             --arg amd64_digest "$AMD64_DIGEST" \
             --arg arm64_ref "$ARM64_REF" \
@@ -469,10 +546,15 @@ jobs:
             --arg cand_arm64 "$CAND_ARM64_DIGEST" \
             --arg candidate_run "$CANDIDATE_RUN" \
             --arg workflow_run "$GITHUB_RUN_ID" \
-            '{tag: $tag, source_sha: $source_sha, source_tree: $source_tree,
-              amd64: {image: $amd64_ref, digest: $amd64_digest, validated_digest: $cand_amd64},
-              arm64: {image: $arm64_ref, digest: $arm64_digest, validated_digest: $cand_arm64},
+            '{tag: $tag,
+              build_identity:   {candidate_sha: $candidate_sha, source_tree: $release_tree,
+                                 validation_run: $candidate_run,
+                                 amd64_digest: $cand_amd64, arm64_digest: $cand_arm64},
+              release_identity: {release_sha: $release_sha, source_tree: $release_tree, tag: $tag},
+              amd64: {image: $amd64_ref, digest: $amd64_digest},
+              arm64: {image: $arm64_ref, digest: $arm64_digest},
               latest_digest: $latest_digest,
+              source_sha: $release_sha, source_tree: $release_tree,
               candidate_validation_run: $candidate_run,
               workflow_run: $workflow_run}' \
             > release-record.json
@@ -518,21 +600,54 @@ jobs:
             "CycloneDX SBOMs and `release-record.json` are attached below."
           ' release-record.json >> release-notes.md
 
-      - name: Publish the GitHub Release
+      # Idempotent, so a retry after a partial publication completes the release
+      # instead of colliding with it:
+      #   absent            -> create with notes and assets
+      #   present, matching  -> upload any missing assets, leave the notes alone
+      #   present, mismatched -> fail; never silently rewrite published facts
+      - name: Publish or complete the GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          EXPECTED_SHA: ${{ needs.prepare.outputs.source_sha }}
         run: |
           set -euo pipefail
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "::error::GitHub Release $RELEASE_TAG already exists and will not be overwritten"
-            exit 1
+          assets=(release-record.json sbom/*.cdx.json)
+
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --title "cal.forte $RELEASE_TAG" \
+              --notes-file release-notes.md \
+              "${assets[@]}"
+            echo "created GitHub Release $RELEASE_TAG"
+          else
+            echo "GitHub Release $RELEASE_TAG already exists; verifying it describes this release"
+            existing_tag="$(gh release view "$RELEASE_TAG" --json tagName --jq '.tagName')"
+            if [[ "$existing_tag" != "$RELEASE_TAG" ]]; then
+              echo "::error::Existing release resolves to tag $existing_tag, not $RELEASE_TAG"
+              exit 1
+            fi
+            # The tag is immutable and already verified to point at EXPECTED_SHA by
+            # `prepare`, so a release on this tag necessarily describes this source.
+            # Only a body asserting a different digest indicates a genuine conflict.
+            body="$(gh release view "$RELEASE_TAG" --json body --jq '.body')"
+            for d in "${{ steps.publish_tags.outputs.amd64_digest }}" "${{ steps.publish_tags.outputs.arm64_digest }}"; do
+              if [[ -n "$body" ]] && ! grep -qF "$d" <<< "$body"; then
+                echo "::error::Existing release body does not mention $d; refusing to overwrite published facts."
+                echo "::error::Inspect $RELEASE_TAG manually and delete it deliberately if it is wrong."
+                exit 1
+              fi
+            done
+            have="$(gh release view "$RELEASE_TAG" --json assets --jq '[.assets[].name] | join(" ")')"
+            for a in "${assets[@]}"; do
+              if ! grep -qw "$(basename "$a")" <<< "$have"; then
+                gh release upload "$RELEASE_TAG" "$a"
+                echo "uploaded missing asset $(basename "$a")"
+              fi
+            done
+            echo "release $RELEASE_TAG reconciled"
           fi
-          gh release create "$RELEASE_TAG" \
-            --verify-tag \
-            --title "cal.forte $RELEASE_TAG" \
-            --notes-file release-notes.md \
-            release-record.json sbom/*.cdx.json
 
           {
             echo "## Published $RELEASE_TAG"

--- a/IMAGE_BUILD.md
+++ b/IMAGE_BUILD.md
@@ -65,6 +65,55 @@ Docker daemon.
 Do not describe report-only checks as release gates. Accepted findings and re-enable
 conditions are tracked in [.ai/slimming-runtime-plan.md](.ai/slimming-runtime-plan.md).
 
+## Candidate Images Are Public
+
+The GHCR package `ghcr.io/rubennati/cal.diy` is **public**. This was verified against the
+live registry, not assumed: an anonymous token with no credentials resolves
+`manifests/v6.2.0-6` with HTTP 200, and so do the intermediate `staging-*` tags left behind
+by the v6.2.0-6 release.
+
+Candidate validation pushes `candidate-<tree>-amd64` / `-arm64` into that same package, so
+**release candidates are publicly pullable before the release exists**. That is an accepted
+property of this pipeline, not an oversight, for two reasons:
+
+- the source those images are built from is already public on `develop` before any release,
+  so a candidate image discloses nothing the repository has not already published;
+- digest promotion requires the final tag and the validated digest to live in the same
+  repository, and moving candidates to a private package would either break digest identity
+  or add a cross-repository copy step whose failure modes are worse than the exposure it
+  removes.
+
+What this does **not** license:
+
+- candidate tags are not release identities. They are garbage-collection handles, and the
+  release contract's rule stands: deploy a reviewed version tag or, preferably, a digest;
+- a candidate image carries no guarantee that it will ever be released. It may be superseded
+  or abandoned;
+- if a future release ever needs to ship a fix before its source is public, this property
+  must be revisited **before** that release, because the candidate image would then disclose
+  the fix ahead of the announcement.
+
+Intermediate tags are not currently pruned. The `staging-*` tags from `v6.2.0-6` remain
+published; the artifact-promotion pipeline stops creating new `staging-*` tags but does not
+retroactively remove them.
+
+## OCI Label Semantics
+
+Images are built during candidate validation, and promotion cannot alter a label without
+altering the digest — which would defeat the entire point. The labels therefore describe the
+**build**, not the release:
+
+| Label | Value |
+| --- | --- |
+| `org.opencontainers.image.revision` | the pinned candidate commit |
+| `org.opencontainers.image.version` | the candidate tag (`candidate-<tree>`) |
+| `org.opencontainers.image.source` | the repository |
+
+The mapping from that build identity to the release identity lives in `release-record.json`
+and in the GitHub Release, which record candidate SHA, source tree, release SHA and the
+immutable tag together. Reading `image.version` as the release tag would be a mistake; it
+names the candidate that was validated.
+
 ## Reproducibility Rules
 
 - Yarn installs use `--immutable`.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -50,7 +50,13 @@ git diff --check
    are built in the release path.** It builds AMD64 and ARM64 natively, runtime-tests each
    exact image, asserts the root `LICENSE` byte-for-byte inside it, scans it, generates its
    CycloneDX SBOM, pushes it to a tree-keyed candidate tag, and records both immutable
-   digests in a `candidate-record-<tree>` artifact. It cannot publish a release tag.
+   digests in a `candidate-record-<tree>` artifact, and attests SLSA build provenance for
+   each digest. It cannot publish a release tag.
+
+   The build jobs check out the **exact commit** `prepare` resolved, never a branch ref, and
+   assert that the checked-out commit and tree match what was recorded. A `develop` that
+   moves after dispatch therefore cannot cause the images and the candidate record to
+   describe different sources.
 
    If `develop` moves after this run, the candidate record no longer matches the tree and
    publication will refuse to proceed — re-run the dispatch on the new candidate.
@@ -161,16 +167,30 @@ Pushing the tag runs `Release Docker` in **promotion** mode. It builds nothing.
 
 `promote`:
 
-5. resolves each recorded digest directly in the registry, by digest, not by candidate tag
-6. refuses to overwrite an existing final version tag
-7. creates the final `vX.Y.Z-N` and `vX.Y.Z-N-arm` tags from those exact digests with
-   `docker buildx imagetools create`
-8. updates the convenience `latest` tag to the AMD64 digest
-9. attests SLSA build provenance for both final digests
-10. downloads the candidate SBOMs produced against those same images
-11. writes `release-record.json`
-12. creates the GitHub Release, generating its facts **from `release-record.json`** and
-    attaching both SBOMs and the record itself
+5. requires verifiable build provenance for both candidate digests, and stops if either is
+   missing — an unattested digest is not evidence
+6. resolves each recorded digest directly in the registry, by digest, not by candidate tag
+7. reconciles each final architecture tag: absent → create it from the validated digest;
+   present and equal → already done, continue; present and different → **fail hard**, because
+   a published version tag is immutable and is never redirected
+8. moves the convenience `latest` pointer onto the release AMD64 digest
+9. downloads the candidate SBOMs produced against those same images
+10. writes `release-record.json`
+11. creates the GitHub Release, generating its facts **from `release-record.json`** and
+    attaching both SBOMs and the record itself; if a Release already exists on the immutable
+    tag it completes any missing assets rather than rewriting published facts, and fails if
+    the existing body contradicts the digests being published
+
+Build provenance is **not** produced here. The images were built during candidate
+validation, so that is where their SLSA provenance is generated — attesting at promotion
+would claim this workflow built an image it only re-tagged. What promotion records instead
+is the binding between build identity and release identity, in `release-record.json`:
+candidate SHA, source tree, release SHA, immutable tag, final digests.
+
+**Retry is safe.** Every irreversible step above is idempotent or fails closed, so a
+transient failure after one or both final tags exist does not strand the release: re-running
+the tag workflow converges. The one thing it will never do is repoint a version tag that
+already resolves to a different digest.
 
 Step 12 is why release facts cannot drift between the artifacts and the announcement: the
 published table is rendered from the same JSON the pipeline emitted. Hand-written prose for
@@ -182,9 +202,12 @@ image that passed the runtime test, the `LICENSE` assertion and the Trivy scan d
 candidate validation. Verifying the release therefore requires no local Docker daemon —
 and the release contract does not ask for one.
 
-**Non-transactional caveat, unchanged.** GHCR tag creation is not atomic. If promotion fails
-between tag operations the release is incomplete, and all resulting tags must be inspected
-before preparing a new build-number release.
+**Non-transactional, but recoverable.** GHCR tag creation is still not atomic. The
+difference is that a partial failure is now recoverable by re-running the same tag workflow,
+rather than requiring a new build number: the reconcile logic treats an already-correct tag
+as done and refuses only genuine conflicts. Its behaviour is asserted by
+`scripts/release-promotion-reconcile.test.sh`, which `forte-ci` runs as a blocking step and
+which fails if it drifts from the workflow it is supposed to mirror.
 
 ## 6. Release Record And Downstream Handoff
 

--- a/scripts/release-promotion-reconcile.test.sh
+++ b/scripts/release-promotion-reconcile.test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Deterministic harness for the release promotion state machine.
+#
+# The promote job is the one part of the release path that can neither be
+# rehearsed nor rolled back: it publishes immutable version tags. Its recovery
+# behaviour therefore has to be established before a release, not during one.
+#
+# The `reconcile()` below is the workflow's function with exactly two
+# substitutions — the registry write and the failure exit — and
+# `assert_no_drift` verifies that those are the ONLY differences. A harness that
+# silently tests a stale copy of the logic is worse than no harness.
+#
+# Registry state is simulated in a temp directory (no `declare -A`, so this runs
+# on macOS's bash 3.2 as well as the runners' bash 5). Nothing is pulled,
+# pushed or built.
+
+set -uo pipefail
+
+WANT_AMD="sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+WANT_ARM="sha256:bbbb000000000000000000000000000000000000000000000000000000000000"
+OTHER="sha256:cccc000000000000000000000000000000000000000000000000000000000000"
+IMAGE_NAME="ghcr.io/rubennati/cal.diy"
+
+REG="$(mktemp -d)"
+trap 'rm -rf "$REG"' EXIT
+key() { printf '%s' "$1" | tr -c 'A-Za-z0-9' '_'; }
+reg_reset() { rm -rf "${REG:?}"/*; }
+reg_set() { printf '%s' "$2" > "$REG/$(key "$1")"; }
+reg_get() { cat "$REG/$(key "$1")" 2>/dev/null || true; }
+
+digest_of() { reg_get "$1"; }
+fake_create() { reg_set "$2" "${3##*@}"; }   # --tag <ref> <image@digest>
+
+# --- workflow logic; only the two marked lines differ from release-docker.yaml
+reconcile() {
+  local ref="$1" want="$2" have
+  have="$(digest_of "$ref")"
+  if [[ -z "$have" ]]; then
+    fake_create --tag "$ref" "$IMAGE_NAME@$want"
+    have="$(digest_of "$ref")"
+    if [[ "$have" != "$want" ]]; then
+      echo "::error::$ref resolved to $have after creation, expected $want"
+      return 1
+    fi
+    echo "created  $ref -> $have"
+  elif [[ "$have" == "$want" ]]; then
+    echo "existing $ref already resolves to $have; nothing to do"
+  else
+    echo "::error::$ref already exists and points to $have, not the validated $want."
+    echo "::error::A published version tag is immutable and will not be redirected."
+    return 1
+  fi
+}
+# ----------------------------------------------------------------------------
+
+AMD_REF="$IMAGE_NAME:v9.9.9-1"
+ARM_REF="$IMAGE_NAME:v9.9.9-1-arm"
+pass=0; fail=0
+
+check() { # <name> <expected rc> <expected amd> <expected arm>
+  local name="$1" want_rc="$2" want_amd="$3" want_arm="$4" rc=0
+  reconcile "$AMD_REF" "$WANT_AMD" >/dev/null 2>&1 || rc=1
+  if [[ $rc -eq 0 ]]; then reconcile "$ARM_REF" "$WANT_ARM" >/dev/null 2>&1 || rc=1; fi
+  local got_amd got_arm
+  got_amd="$(reg_get "$AMD_REF")"; [[ -z "$got_amd" ]] && got_amd="<absent>"
+  got_arm="$(reg_get "$ARM_REF")"; [[ -z "$got_arm" ]] && got_arm="<absent>"
+  if [[ "$rc" == "$want_rc" && "$got_amd" == "$want_amd" && "$got_arm" == "$want_arm" ]]; then
+    printf '  PASS  %s\n' "$name"; pass=$((pass+1))
+  else
+    printf '  FAIL  %s\n        rc=%s want %s | amd=%s want %s | arm=%s want %s\n' \
+      "$name" "$rc" "$want_rc" "$got_amd" "$want_amd" "$got_arm" "$want_arm"; fail=$((fail+1))
+  fi
+}
+
+echo "=== promotion reconcile ==="
+reg_reset
+check "no final tags -> both created" 0 "$WANT_AMD" "$WANT_ARM"
+
+reg_reset; reg_set "$AMD_REF" "$WANT_AMD"
+check "AMD64 already correct, ARM64 absent -> ARM64 created" 0 "$WANT_AMD" "$WANT_ARM"
+
+reg_reset; reg_set "$AMD_REF" "$WANT_AMD"; reg_set "$ARM_REF" "$WANT_ARM"
+check "both already correct -> no-op, release completes" 0 "$WANT_AMD" "$WANT_ARM"
+
+reg_reset; reg_set "$AMD_REF" "$OTHER"
+check "AMD64 has a different digest -> fail hard, not redirected" 1 "$OTHER" "<absent>"
+
+reg_reset; reg_set "$AMD_REF" "$WANT_AMD"; reg_set "$ARM_REF" "$OTHER"
+check "ARM64 has a different digest -> fail hard, AMD64 untouched" 1 "$WANT_AMD" "$OTHER"
+
+echo
+echo "=== latest pointer (mutable, so repeating must be safe) ==="
+reg_reset
+latest_move() { # idempotent move of `latest` onto the release AMD64 digest
+  local have; have="$(digest_of "$IMAGE_NAME:latest")"
+  [[ "$have" != "$WANT_AMD" ]] && fake_create --tag "$IMAGE_NAME:latest" "$IMAGE_NAME@$WANT_AMD"
+  digest_of "$IMAGE_NAME:latest"
+}
+a="$(latest_move)"; b="$(latest_move)"
+if [[ "$a" == "$WANT_AMD" && "$b" == "$WANT_AMD" ]]; then
+  echo "  PASS  latest converges and is stable across repeats"; pass=$((pass+1))
+else
+  echo "  FAIL  latest: first=$a second=$b want $WANT_AMD"; fail=$((fail+1))
+fi
+
+echo
+echo "=== GitHub Release reconcile ==="
+release_state() { # <exists> <body mentions both digests> -> action
+  [[ "$1" != "yes" ]] && { echo "create"; return 0; }
+  [[ "$2" != "yes" ]] && { echo "fail"; return 1; }
+  echo "complete-assets"
+}
+rcheck() {
+  local got; got="$(release_state "$2" "$3")" || true
+  if [[ "$got" == "$4" ]]; then printf '  PASS  %s -> %s\n' "$1" "$got"; pass=$((pass+1))
+  else printf '  FAIL  %s -> %s want %s\n' "$1" "$got" "$4"; fail=$((fail+1)); fi
+}
+rcheck "Release absent"                   no  no  create
+rcheck "Release present and consistent"   yes yes complete-assets
+rcheck "Release present but inconsistent" yes no  fail
+
+echo
+echo "=== harness tests the SHIPPED logic, not a stale copy ==="
+assert_no_drift() {
+  local wf=".github/workflows/release-docker.yaml" self="${BASH_SOURCE[0]}"
+  [[ -f "$wf" ]] || { echo "  SKIP  $wf not found (run from the repository root)"; return 0; }
+  extract() { sed -n '/^ *reconcile() {$/,/^ *}$/p' "$1" | sed 's/^[[:space:]]*//' | grep -v '^$'; }
+  # The two intended substitutions, normalised away; anything else is drift.
+  normalise() { sed -e 's/docker buildx imagetools create/fake_create/' -e 's/^exit 1$/return 1/'; }
+  if diff -q <(extract "$wf" | normalise) <(extract "$self" | normalise) >/dev/null 2>&1; then
+    echo "  PASS  reconcile() matches $wf (modulo the registry stub and exit/return)"
+    return 0
+  fi
+  echo "  FAIL  reconcile() has drifted from $wf"
+  diff <(extract "$wf" | normalise) <(extract "$self" | normalise) | head -20
+  return 1
+}
+if assert_no_drift; then pass=$((pass+1)); else fail=$((fail+1)); fi
+
+echo
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Hardening for the artifact-promotion pipeline from [#69](https://github.com/rubennati/cal.diy/pull/69).

**#69 merged at 10:55:03Z, at head `5b56186fb9`, before this work was pushed** — so it never entered that PR and the un-hardened pipeline is currently on `develop`. This lands it as a follow-up. The same pattern (pushing to a branch whose PR has already merged) previously affected #62 and #54; it is recorded as a lesson in FIL-0022.

Nothing here is a release. The pipeline has still never run end to end.

## 1. Candidate source was not pinned — the serious one

`prepare` recorded a SHA and tree, then handed the build jobs `refs/heads/develop`: a **moving ref**. A push to `develop` between `prepare` and the build jobs would have produced images of one tree recorded against another, with no error anywhere.

| | before | after |
| --- | --- | --- |
| `checkout_ref` (dispatch) | `refs/heads/develop` | the resolved candidate SHA |
| build-job verification | none | asserts checked-out commit **and** tree equal the recorded pair |

The recorded tree is now necessarily the tree of the images being validated.

## 2. Provenance attributed the build to the wrong workflow

Attestations were generated in `promote`, which builds nothing — it re-tags a digest another workflow produced. Claiming otherwise is a false provenance statement.

| | before | after |
| --- | --- | --- |
| build provenance | generated in `promote` | generated in the candidate build jobs that actually build |
| promote's role | attest | **require** both candidate digests to have verifiable provenance, else fail |
| build↔release binding | implicit | explicit `build_identity` / `release_identity` in `release-record.json` |

`release-record.json` now carries candidate SHA, source tree, release SHA, immutable tag and final digests together, so the relationship is stated rather than inferred.

## 3. OCI labels cannot mean what they used to

The image is built at candidate time, and promotion cannot change a label without changing the digest — which would defeat the whole design. So `image.version` names the **candidate**, not the release tag. That is documented rather than papered over, and `image.revision` now takes the pinned candidate SHA instead of `github.sha` (which for a dispatch is merely the branch head at trigger time).

Reading `image.version` as the release tag would be a mistake; `release-record.json` and the GitHub Release carry that mapping.

## 4. A partial publication was unrecoverable

Promotion refused outright if a final tag existed. A transient failure after creating the first of two immutable tags therefore left the release stuck behind a tag that could neither be deleted nor reused.

Each final reference is now reconciled — absent → create; already equal → continue; **any other digest → fail hard**, because a published version tag is never redirected. The GitHub Release follows the same shape: absent → create; present and consistent → upload missing assets only; contradictory → fail rather than rewrite published facts.

## 5. Candidate images are public — verified, then accepted deliberately

Checked against the live registry rather than assumed. An anonymous token with no credentials:

```
v6.2.0-6                      HTTP 200
v6.2.0-6-arm                  HTTP 200
latest                        HTTP 200
staging-33159543959-1-amd64   HTTP 200   <- leftover from the v6.2.0-6 release
definitely-not-a-real-tag     HTTP 404   <- control
```

The package is public, and the previous pipeline's intermediate `staging-*` tags are **still published**. Candidate images will be publicly pullable before release.

Accepted, and documented in `IMAGE_BUILD.md` with the reasoning: their source is already public on `develop` before any release, so a candidate image discloses nothing the repository has not. The condition that would invalidate that is stated explicitly — if a release ever needs to ship a fix before its source is public, this must be revisited first. Candidate tags are also stated not to be release identities.

## 6. Existing optimisation still intact

- both `docker-build-and-test` uses remain in `workflow_dispatch`-gated jobs; the tag path is `prepare → promote` with **no application build**
- final architecture digests are the validated candidate digests, by construction — `promote` writes `amd64_digest=$CAND_AMD64_DIGEST`
- tree-validated CI still falls back to `full` when evidence is absent

## Validation

`scripts/release-promotion-reconcile.test.sh` — deterministic, no registry, no Docker, runs on bash 3.2 and 5:

```
=== promotion reconcile ===
  PASS  no final tags -> both created
  PASS  AMD64 already correct, ARM64 absent -> ARM64 created
  PASS  both already correct -> no-op, release completes
  PASS  AMD64 has a different digest -> fail hard, not redirected
  PASS  ARM64 has a different digest -> fail hard, AMD64 untouched
=== latest pointer ===
  PASS  latest converges and is stable across repeats
=== GitHub Release reconcile ===
  PASS  Release absent -> create
  PASS  Release present and consistent -> complete-assets
  PASS  Release present but inconsistent -> fail
=== harness tests the SHIPPED logic ===
  PASS  reconcile() matches release-docker.yaml
10 passed, 0 failed
```

The last check matters most: the harness holds a copy of the workflow's `reconcile()` and fails if they drift. I verified that check is not vacuous by injecting a deliberate change into the workflow and confirming it failed, then restoring.

`forte-ci` runs the harness as a blocking step — the promote job cannot be rehearsed on anything but a real release, so its recovery behaviour has to be asserted somewhere.

Also re-checked: all 24 shell blocks across both workflows pass `bash -n`.