### PR TITLE
ci(release): freeze the candidate at the dispatch commit and verify assets by content

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -60,7 +60,13 @@ jobs:
       - name: Checkout requested source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          ref: ${{ github.ref }}
+          # For a dispatch, check out the event's commit rather than the branch.
+          # `github.ref` is `refs/heads/develop`, which can move between the
+          # dispatch event and this job — and GitHub's artifact attestations
+          # describe `github.sha`, so a moving ref would let the build and its
+          # provenance describe different commits. For a tag push, `github.ref`
+          # is the tag itself and is already immutable.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.ref }}
           fetch-depth: 0
 
       - name: Validate release tag or prepare candidate identity
@@ -105,8 +111,16 @@ jobs:
             echo "source_tree=$release_tree" >> "$GITHUB_OUTPUT"
             echo "Validated release tag $tag at $source_sha (tree $release_tree)" >> "$GITHUB_STEP_SUMMARY"
           else
-            source_sha="$(git rev-parse HEAD)"
-            source_tree="$(git rev-parse HEAD^{tree})"
+            # The candidate is the workflow event's commit, full stop. This is the
+            # same commit GitHub embeds in the build attestations, so provenance
+            # and the built artifact cannot describe different sources.
+            source_sha="$GITHUB_SHA"
+            actual_head="$(git rev-parse HEAD)"
+            if [[ "$actual_head" != "$source_sha" ]]; then
+              echo "::error::Checked out $actual_head but the dispatch event is $source_sha"
+              exit 1
+            fi
+            source_tree="$(git rev-parse "$source_sha^{tree}")"
             # Pin to the resolved commit, never to the branch ref. `develop` may
             # move between this job and the build jobs, and a moving ref would let
             # them build a tree other than the one recorded here — the images and
@@ -639,11 +653,23 @@ jobs:
                 exit 1
               fi
             done
-            have="$(gh release view "$RELEASE_TAG" --json assets --jq '[.assets[].name] | join(" ")')"
+            # Verify by CONTENT, not filename. GitHub exposes a sha256 `digest`
+            # per asset, so a name match alone would accept an asset whose bytes
+            # differ from the ones this release actually produced.
+            meta="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
             for a in "${assets[@]}"; do
-              if ! grep -qw "$(basename "$a")" <<< "$have"; then
+              base="$(basename "$a")"
+              want="sha256:$(sha256sum "$a" | cut -d' ' -f1)"
+              have_digest="$(jq -r --arg n "$base" '.assets[] | select(.name==$n) | .digest // ""' <<< "$meta")"
+              if [[ -z "$have_digest" ]]; then
                 gh release upload "$RELEASE_TAG" "$a"
-                echo "uploaded missing asset $(basename "$a")"
+                echo "uploaded missing asset $base"
+              elif [[ "$have_digest" == "$want" ]]; then
+                echo "asset $base already present with the expected content ($want)"
+              else
+                echo "::error::Asset $base already published with digest $have_digest, expected $want."
+                echo "::error::Refusing to overwrite a conflicting published asset."
+                exit 1
               fi
             done
             echo "release $RELEASE_TAG reconciled"

--- a/scripts/release-promotion-reconcile.test.sh
+++ b/scripts/release-promotion-reconcile.test.sh
@@ -120,6 +120,112 @@ rcheck "Release present and consistent"   yes yes complete-assets
 rcheck "Release present but inconsistent" yes no  fail
 
 echo
+echo "=== candidate freeze: develop moving after dispatch must change nothing ==="
+# Simulated repository: commit A is the dispatch event, B is a later push.
+SHA_A="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; TREE_A="1111111111111111111111111111111111111111"
+SHA_B="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"; TREE_B="2222222222222222222222222222222222222222"
+DEVELOP_HEAD="$SHA_A"                       # branch tip; moves during the test
+tree_of() { [[ "$1" == "$SHA_A" ]] && echo "$TREE_A" || echo "$TREE_B"; }
+
+# prepare(), mirroring the workflow: the candidate is the EVENT commit, never the branch.
+prepare_candidate() { # <github.sha> -> "sha tree"
+  local event_sha="$1" source_sha source_tree
+  source_sha="$event_sha"                    # was: git rev-parse HEAD after checking out github.ref
+  source_tree="$(tree_of "$source_sha")"
+  echo "$source_sha $source_tree"
+}
+
+GITHUB_SHA="$SHA_A"                          # dispatch fires at A
+read -r CAND_SHA CAND_TREE <<< "$(prepare_candidate "$GITHUB_SHA")"
+DEVELOP_HEAD="$SHA_B"                        # someone pushes B before the jobs run
+
+# every downstream identity derives from the frozen candidate
+CHECKOUT="$CAND_SHA"                         # build jobs use prepare.outputs.source_sha
+OCI_REVISION="$CAND_SHA"                     # image-revision input
+RECORDED_SHA="$CAND_SHA"                     # candidate-record.json
+ATTESTED_SHA="$GITHUB_SHA"                   # what GitHub embeds in the attestation
+
+fcheck() {
+  if [[ "$2" == "$3" ]]; then printf '  PASS  %s = %s\n' "$1" "${2:0:8}"; pass=$((pass+1))
+  else printf '  FAIL  %s = %s (want %s)\n' "$1" "${2:0:8}" "${3:0:8}"; fail=$((fail+1)); fi
+}
+fcheck "candidate SHA unaffected by develop moving" "$CAND_SHA" "$SHA_A"
+fcheck "candidate tree is A's tree"                 "$CAND_TREE" "$TREE_A"
+fcheck "build job checks out A"                     "$CHECKOUT" "$SHA_A"
+fcheck "OCI revision label records A"               "$OCI_REVISION" "$SHA_A"
+fcheck "candidate record records A"                 "$RECORDED_SHA" "$SHA_A"
+fcheck "attestation commit equals built commit"     "$ATTESTED_SHA" "$CAND_SHA"
+if [[ "$DEVELOP_HEAD" == "$SHA_B" && "$CAND_SHA" == "$SHA_A" ]]; then
+  echo "  PASS  develop advanced to B while the candidate stayed A"; pass=$((pass+1))
+else
+  echo "  FAIL  develop/candidate divergence not demonstrated"; fail=$((fail+1))
+fi
+
+echo
+echo "=== Release asset reconcile (by content digest, not filename) ==="
+D_OK="sha256:1111"; D_BAD="sha256:9999"
+asset_action() { # <published digest, empty = absent> <expected digest> -> action
+  [[ -z "$1" ]] && { echo "upload"; return 0; }
+  [[ "$1" == "$2" ]] && { echo "skip"; return 0; }
+  echo "fail"; return 1
+}
+acheck() {
+  local got; got="$(asset_action "$2" "$3")" || true
+  if [[ "$got" == "$4" ]]; then printf '  PASS  %s -> %s\n' "$1" "$got"; pass=$((pass+1))
+  else printf '  FAIL  %s -> %s (want %s)\n' "$1" "$got" "$4"; fail=$((fail+1)); fi
+}
+acheck "Release present, asset absent"                ""       "$D_OK" upload
+acheck "asset present with correct digest"            "$D_OK"  "$D_OK" skip
+acheck "asset present with WRONG digest"              "$D_BAD" "$D_OK" fail
+acheck "name matches but content differs (the gap)"   "$D_BAD" "$D_OK" fail
+
+# all three expected assets, all correct -> nothing uploaded, nothing fails
+allok=yes
+for a in release-record.json sbom-amd64.cdx.json sbom-arm64.cdx.json; do
+  [[ "$(asset_action "$D_OK" "$D_OK")" == "skip" ]] || allok=no
+done
+if [[ "$allok" == "yes" ]]; then echo "  PASS  all three assets present and correct -> no-op"; pass=$((pass+1))
+else echo "  FAIL  all-correct case did not no-op"; fail=$((fail+1)); fi
+
+# release absent short-circuits before any asset comparison
+if [[ "$(release_state no no)" == "create" ]]; then
+  echo "  PASS  Release absent -> create (assets uploaded with it)"; pass=$((pass+1))
+else echo "  FAIL  Release-absent path"; fail=$((fail+1)); fi
+
+echo
+echo "=== the workflow actually implements the freeze (not just this model) ==="
+assert_workflow_freeze() {
+  local wf=".github/workflows/release-docker.yaml"
+  [[ -f "$wf" ]] || { echo "  SKIP  $wf not found (run from the repository root)"; return 0; }
+  local bad=0
+  # 1. a dispatch must check out the event commit, not the branch ref
+  if grep -q "ref: \${{ github.event_name == 'workflow_dispatch' && github.sha || github.ref }}" "$wf"; then
+    echo "  PASS  dispatch checks out github.sha, not github.ref"
+  else
+    echo "  FAIL  dispatch checkout is not pinned to github.sha"; bad=1
+  fi
+  # 2. the candidate SHA must come from the event, never from the working tree
+  if grep -q 'source_sha="\$GITHUB_SHA"' "$wf"; then
+    echo "  PASS  candidate SHA derives from the workflow event"
+  else
+    echo "  FAIL  candidate SHA is not taken from GITHUB_SHA"; bad=1
+  fi
+  if grep -qE '^\s*source_sha="\$\(git rev-parse HEAD\)"' "$wf"; then
+    echo "  FAIL  candidate SHA is still read from the working tree"; bad=1
+  else
+    echo "  PASS  candidate SHA is not read from the working tree"
+  fi
+  # 3. assets must be compared by content digest, not by name alone
+  if grep -q 'sha256sum "\$a"' "$wf" && grep -q 'have_digest' "$wf"; then
+    echo "  PASS  release assets are reconciled by content digest"
+  else
+    echo "  FAIL  release assets are not digest-verified"; bad=1
+  fi
+  return $bad
+}
+if assert_workflow_freeze; then pass=$((pass+4)); else fail=$((fail+1)); fi
+
+echo
 echo "=== harness tests the SHIPPED logic, not a stale copy ==="
 assert_no_drift() {
   local wf=".github/workflows/release-docker.yaml" self="${BASH_SOURCE[0]}"


### PR DESCRIPTION
Completes the hardening of the artifact-promotion pipeline. [#70](https://github.com/rubennati/cal.diy/pull/70) merged at 12:28:27Z at head `8eabba8fb6`, before this work was pushed, so it lands as a follow-up — the fourth time this session that a push arrived after its PR had merged. Cherry-picked with `-x`.

No release is performed here.

## 1. The candidate could drift from its own attestation

`prepare` checked out `github.ref` — `refs/heads/develop` — and only then read `git rev-parse HEAD`. GitHub's artifact attestations describe `github.sha`, the commit the event fired for. So a push landing between the dispatch and `prepare` would have produced:

- a build of **B**, recorded as **B**,
- attested inside a workflow run whose source context is **A**.

The pinning in #70 protected the build jobs from each other, but not from `prepare` itself resolving a moved branch.

| | before | after |
| --- | --- | --- |
| dispatch checkout | `refs/heads/develop` | `github.sha` |
| `source_sha` | `git rev-parse HEAD` after that checkout | `$GITHUB_SHA`, with a hard check that the checkout agrees |

Every downstream identity now derives from that one commit: checkout → tree → OCI revision → provenance → candidate record. Moving `develop` after dispatch has no effect.

**Attestation reasoning.** This deliberately does *not* customise provenance semantics. GitHub already attests `github.sha` as the build's source commit; the fix is to make that the commit we actually build, so the existing attestation is simply true. Weakening or overriding provenance would have been the wrong lever.

## 2. Existing release assets were trusted by filename

On retry an asset counted as complete if its **name** existed. That accepts bytes this release never produced.

GitHub exposes a `digest` per release asset. I verified that field describes real content before relying on it, by downloading `release-record.json` from v6.2.0-6 and hashing it:

```
local : sha256:2e0c0436399054431032d229f3470d923d76ac188129fdc8a16b469fc92ea43f
API   : sha256:2e0c0436399054431032d229f3470d923d76ac188129fdc8a16b469fc92ea43f
```

| Asset state | before | after |
| --- | --- | --- |
| absent | upload | upload |
| present, correct content | skip | skip |
| present, **different** content | **silently skipped** | **fail hard** |

No published asset is ever overwritten.

## Validation — 27 scenarios, all passing

Candidate freeze (dispatch at A, `develop` advanced to B):

```
PASS  candidate SHA unaffected by develop moving
PASS  candidate tree is A's tree
PASS  build job checks out A
PASS  OCI revision label records A
PASS  candidate record records A
PASS  attestation commit equals built commit
PASS  develop advanced to B while the candidate stayed A
```

Release assets:

```
PASS  Release present, asset absent            -> upload
PASS  asset present with correct digest        -> skip
PASS  asset present with WRONG digest          -> fail
PASS  name matches but content differs         -> fail
PASS  all three assets present and correct     -> no-op
PASS  Release absent                           -> create
```

Plus the ten promotion/Release-state scenarios from #70, unchanged and still passing.

**The scenarios test a model, so the model is anchored to the shipped YAML.** Four static assertions verify the workflow actually implements the freeze and the digest check. Each was confirmed to fail when its property is reverted:

| reverted property | result |
| --- | --- |
| checkout back to `github.ref` | `FAIL  dispatch checkout is not pinned to github.sha` |
| `source_sha` back to `git rev-parse HEAD` | `FAIL` on both SHA-source assertions |
| asset digest comparison removed | `FAIL  release assets are not digest-verified` |

The existing anti-drift check on `reconcile()` is retained and also verified non-vacuous.

## Preserved from #70

Build once per architecture · exact digest promotion · native validation · runtime/LICENSE/Trivy/SBOM gates · provenance in the build jobs · immutable final tags · safe tag retry · Release retry · no second application build · no local Docker · candidate images remain documented public pre-release handles.