### PR TITLE
docs: add the cal.forte user and operator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ tracked as open issues; see [docs/SELF_HOST_PRODUCTIZATION.md](docs/SELF_HOST_PR
 
 ## 📚 Documentation & knowledge base
 
+**Using or operating cal.forte? Start at [docs/README.md](docs/README.md)** — overview,
+capabilities, getting started, configuration, security model, operations and roadmap.
+
+The records below are the fork's engineering memory. You should not need them to run the
+product.
+
 Everything we know about this fork, grouped. Entry point for tooling: [.ai/index.md](.ai/index.md).
 
 **Fork process & release**
@@ -188,14 +194,27 @@ Full list with rationale: [FORK_DIVERGENCE.md](FORK_DIVERGENCE.md). One caveat w
 before you audit: `type-check` runs for only 8 of 113 packages, so a green CI run is not
 proof that the whole tree compiles — [.ai/quality-gates.md](.ai/quality-gates.md).
 
-## Edition & state at a glance
+## Capabilities at a glance
 
-- **Community Edition (MIT)** — Enterprise Edition is absent. **Present:** event types,
-  availability, bookings, calendar/video integrations, payments, webhooks, API v2, embed.
-  **Absent:** Workflows, Insights, SAML/SSO, audit logs, team management (details:
-  [.ai/branding.md](.ai/branding.md)).
-- The old cal.com "buy Enterprise" **paywall is already removed**.
-- App-store apps are **disabled by default** — active only with credentials
-  ([.ai/architecture.md](.ai/architecture.md) §3).
+Community Edition (MIT); Enterprise Edition is absent. The old "buy Enterprise" paywall is
+already removed.
+
+| | |
+| --- | --- |
+| **Supported** | booking pages and event types · availability · calendar and conferencing integrations · sign-in incl. OAuth · **API-key management** · Zapier and Make · personal webhooks · automatic database migrations · AMD64 and ARM64 images with provenance and SBOMs |
+| **Limited** | **scheduled/background jobs** — the container ships no scheduler, so reminders and calendar refresh need an external trigger · recurring-event request validation · Microsoft/Entra tenant restriction |
+| **Planned** | **REST API v2** — the release ships no API service · Teams · Organizations · PBAC |
+| **Not included** | Workflows · Insights · SAML/SSO · video recordings · API v1 · telemetry and ad tracking (removed by this fork) |
+
+**API keys work; the REST API is not shipped.** Keys are created in the UI and consumed
+today by the web integrations (Zapier, Make). They are not yet credentials for a public
+REST API — see [the API v2 roadmap](docs/guide/roadmap/api-v2.md).
+
+This is a summary. The canonical registry — with what Cal.com offers, what upstream
+Cal.diy claims, what cal.forte actually supports, and the evidence for each — is
+**[docs/guide/capabilities.md](docs/guide/capabilities.md)**. Where the two disagree, the
+capability matrix is correct and this summary needs fixing.
+
+📖 **[Full documentation →](docs/README.md)**
 
 For the full upstream README (install reference), see the [`main` branch](https://github.com/rubennati/cal.diy/blob/main/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# cal.forte Documentation
+
+cal.forte is a hardened, review-gated fork of [Cal.diy](https://cal.diy) — the MIT
+community edition of Cal.com. This is the documentation for **using and operating** it.
+
+It describes what cal.forte actually does, not what upstream does. Where the fork
+deliberately differs, that difference is stated rather than inherited.
+
+## Start here
+
+| | |
+| --- | --- |
+| [Overview](guide/overview.md) | what cal.forte is, and how it differs from upstream |
+| [Capabilities](guide/capabilities.md) | what is supported, limited or planned — read this first if you are evaluating |
+| [Getting started](guide/getting-started.md) | running an instance |
+| [Deployment contract](guide/deployment.md) | what a deployment must provide |
+
+## Guide
+
+| | |
+| --- | --- |
+| [Configuration](guide/configuration.md) | required and notable settings |
+| [Authentication](guide/authentication.md) | sign-in, sessions, API keys |
+| [Integrations](guide/integrations.md) | calendars, conferencing, automation |
+| [Security model](guide/security.md) | what the product protects, and what it expects from the deployment |
+
+## Operations
+
+| | |
+| --- | --- |
+| [Database migrations](guide/operations/database-migrations.md) | when and how the schema changes |
+| [Upgrading](guide/operations/upgrading.md) | moving between releases |
+| [Background jobs](guide/operations/cron-jobs.md) | **required reading** — scheduled work needs an external trigger |
+| [Troubleshooting](guide/operations/troubleshooting.md) | common symptoms |
+
+## Roadmap
+
+| | |
+| --- | --- |
+| [REST API v2](guide/roadmap/api-v2.md) | evaluated, not shipped |
+
+## Engineering and governance records
+
+This guide is for users and operators. The records below are the fork's engineering
+memory — you should not need them to run cal.forte, and they are linked here so that a
+claim in this guide can always be traced to its source.
+
+| Record | Answers |
+| --- | --- |
+| [FORK_STATUS.md](../FORK_STATUS.md) | current release, image digests, upstream review point |
+| [FORK_DIVERGENCE.md](../FORK_DIVERGENCE.md) | every deliberate difference from upstream |
+| [SECURITY_REVIEW.md](../SECURITY_REVIEW.md) | the per-release security gate |
+| [SECURITY_ASSURANCE.md](../SECURITY_ASSURANCE.md) | what the fork does and does not verify |
+| [IMAGE_BUILD.md](../IMAGE_BUILD.md) | how the published image is built |
+| [RELEASE_PROCESS.md](../RELEASE_PROCESS.md) | how a release is produced |
+| [FORK_PROCESS.md](../FORK_PROCESS.md) | branch model and merge gates |
+
+Release-specific values — tags, digests, dates — live in `FORK_STATUS.md` and are
+deliberately **not** repeated here, so this guide does not go stale between releases.

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -1,0 +1,73 @@
+# Authentication
+
+How people sign in, and how machines authenticate.
+
+## User sign-in
+
+| Method | Status |
+| --- | --- |
+| Email and password | SUPPORTED |
+| Google OAuth | SUPPORTED |
+| Microsoft / Entra OAuth | LIMITED — see below |
+| SAML SSO, SCIM | NOT INCLUDED |
+
+Sessions are handled by NextAuth and signed with `NEXTAUTH_SECRET`.
+
+### Self-registration
+
+Registration is enabled by default and can be switched off:
+
+```
+NEXT_PUBLIC_DISABLE_SIGNUP=true
+```
+
+Disable it on any instance you operate for yourself. An open registration form on a public
+scheduling instance is both an attack foothold and a spam surface.
+
+Note that this flag controls the ordinary registration path. Invitation-token flows are a
+separate mechanism, and the interaction between them is tracked as an open finding
+([#38](https://github.com/rubennati/cal.diy/issues/38)) — relevant if you rely on the flag
+as a hard boundary rather than as a product setting.
+
+### Microsoft / Entra
+
+The Entra sign-in path accepts identities from any Microsoft tenant unless you restrict it
+yourself. If you intend "our organisation's Microsoft accounts", that restriction is not
+applied for you. Tracked as [#23](https://github.com/rubennati/cal.diy/issues/23).
+
+## API keys
+
+**Status: SUPPORTED.** Managed under **Settings → Developer → API keys**.
+
+| Property | Behaviour |
+| --- | --- |
+| Format | `cal_` prefix followed by a random value |
+| Storage | SHA-256 hash only; the plaintext key is shown once, at creation |
+| Expiry | optional — a key can be created that never expires |
+| Revocation | delete the key |
+| Scope | **none** — a key carries the full authority of the user who created it |
+
+### What a key is for today
+
+An API key authenticates the **web-based automation integrations** that ship in the
+release, notably Zapier and Make. Those run inside the web runtime and validate keys
+against the same stored hash.
+
+An API key is **not** currently a credential for a public REST API, because the published
+release does not ship one. See [the API v2 roadmap](roadmap/api-v2.md).
+
+### Handling
+
+Because a key carries full user authority and can be created without expiry:
+
+- create one key per consumer, so you can revoke precisely;
+- set an expiry unless you have a reason not to;
+- treat the plaintext as a password — it is shown once and cannot be recovered;
+- revoke immediately when a consumer is retired.
+
+There is no permission scoping to fall back on. Revocation is the control.
+
+## Two-factor authentication
+
+TOTP is present. Setup failures are known to report poorly, which makes misconfiguration
+hard to diagnose — tracked as [#35](https://github.com/rubennati/cal.diy/issues/35).

--- a/docs/guide/capabilities.md
+++ b/docs/guide/capabilities.md
@@ -1,0 +1,189 @@
+# Capability matrix
+
+**This is the canonical, user-facing record of what cal.forte supports.** Where any other
+document in this repository disagrees with this page about product capability, this page
+wins and the other document is wrong.
+
+## Why this page exists in this form
+
+Upstream feature tables answer one question with one tick: *does the product have X?* That
+is not enough for a fork. A capability can exist in the codebase, be claimed by upstream
+documentation, and still not be usable in the release you are running — and each of those
+is a different fact.
+
+So every row answers four separate questions, and they are never collapsed:
+
+1. **Cal.com** — does the commercial product offer it?
+2. **Cal.diy claim** — does current upstream Community Edition documentation claim it?
+3. **cal.forte status** — what does the current cal.forte release actually support?
+4. **Verification** — what evidence supports that status?
+
+A ✅ in column 2 is an *inventory item to investigate*, not a statement about cal.forte.
+
+## Vocabulary
+
+### Product status
+
+| Status | Meaning |
+| --- | --- |
+| **SUPPORTED** | usable in the published release through a normal user workflow |
+| **LIMITED** | usable, but with a constraint you must know before relying on it |
+| **PLANNED** | not in the published release; intended or under active design |
+| **NOT INCLUDED** | deliberately absent, with no current intent to add it |
+| **EVALUATING** | implementation exists; whether the release supports it end to end is not yet established |
+
+### Verification
+
+Status says what the product does. Verification says how well we know it. They are
+independent — a SUPPORTED feature can still have open findings.
+
+| Term | Meaning |
+| --- | --- |
+| **RUNTIME VERIFIED** | exercised against a running instance |
+| **CODE VERIFIED** | the implementation was read and confirmed to exist and connect |
+| **REVIEWED** | passed the fork's security review for a release |
+| **OPEN FINDINGS** | works, and has recorded findings against it |
+| **NOT YET VERIFIED** | inherited from upstream, not independently checked |
+
+No row is labelled "secure" or "safe". Those are not properties this matrix can assert.
+
+## Scheduling and bookings
+
+| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Event types | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | core product; exercised by the release runtime test |
+| Booking management | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | |
+| Recurring event types | ✅ | ✅ | **LIMITED** | OPEN FINDINGS | recurring request bodies are not validated at runtime — accepted known defect, [#46](https://github.com/rubennati/cal.diy/issues/46) |
+| Private links (hashed URLs) | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
+| Paid events (Stripe / PayPal) | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | app-store apps present; requires provider credentials, unexercised here |
+| Seated events | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
+| Teams | ✅ | ❌ | **PLANNED** | CODE VERIFIED | schema and services exist; **no shipped runtime path creates a team**. [Evaluation](../TEAM_CAPABILITY_EVALUATION.md) |
+| Team event types (round-robin / collective) | ✅ | ❌ | **PLANNED** | CODE VERIFIED | backend intact, UI and authorization removed upstream |
+| Managed event types | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | |
+| Instant meeting | ✅ | ❌ | **NOT INCLUDED** | NOT YET VERIFIED | |
+| Organizations | ✅ | ❌ | **PLANNED** | CODE VERIFIED | no org router; no runtime path |
+
+## Availability
+
+| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Availability schedules | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | |
+| Date overrides | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
+| Buffer times, minimum notice, booking limits | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
+| Travel schedules | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | present in the tree |
+| Out of office | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | present in the tree |
+
+## Calendar integrations
+
+| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Google, Outlook / Office 365, Apple, CalDAV, Exchange, ICS feed | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | require provider credentials; see [Integrations](integrations.md) |
+| Zoho Calendar | ✅ | ✅ | **SUPPORTED** | REVIEWED | fork-specific hardening: server locations constrained to documented regions |
+| Lark, Feishu | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
+| Calendar subscription refresh | ✅ | — | **LIMITED** | CODE VERIFIED | implemented as a scheduled endpoint; needs an external trigger — [Background jobs](operations/cron-jobs.md) |
+
+## Video and conferencing
+
+| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Cal Video (Daily.co), Zoom, Google Meet, Teams, Webex, Jitsi | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | require provider credentials |
+| Video recordings | ✅ | ❌ | **NOT INCLUDED** | — | commercial capability |
+
+## Authentication
+
+| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Email / password | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | [Authentication](authentication.md) |
+| Google OAuth | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | |
+| Microsoft / Entra OAuth | ✅ | ✅ | **LIMITED** | OPEN FINDINGS | tenant restriction is not enforced by default — see [Authentication](authentication.md) |
+| Self-registration | ✅ | ✅ | **SUPPORTED, disableable** | REVIEWED | disable on a single-operator instance |
+| SAML SSO, SCIM | ✅ | ❌ | **NOT INCLUDED** | — | enterprise capability |
+| Impersonation | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | code present despite the upstream ❌; release support not established |
+| API keys | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | creation and revocation in the UI — read the [API and integrations](#automation-integrations-and-api) note below |
+| PBAC (permission-based access control) | ✅ | ❌ | **PLANNED** | REVIEWED | not implemented; the fork's placeholders **deny** rather than grant |
+
+## Automation, integrations and API
+
+| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Webhooks (personal) | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | |
+| Webhooks (team) | ✅ | ❌ | **PLANNED** | OPEN FINDINGS | depends on Teams; ownership middleware has no team branch |
+| Zapier | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | runs inside the web runtime and consumes API keys |
+| Make | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | as above |
+| n8n, Pipedream | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | present in the app store; not exercised |
+| CRM, messaging, AI-agent apps | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | app-store apps are disabled until credentialed |
+| Intercom | ✅ | ✅ | **SUPPORTED** | REVIEWED | fork-specific hardening: configure endpoint authenticated |
+| **REST API v2** | ✅ | ✅ | **PLANNED** | CODE VERIFIED | **the published release ships no API service.** [Roadmap](roadmap/api-v2.md) |
+| API v1 (legacy) | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | not present in the fork |
+| Platform / OAuth clients | ✅ | ✅ | **PLANNED** | CODE VERIFIED | part of the API v2 application; not shipped |
+| Embed | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | packages present; not exercised |
+| Workflows (automations) | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | absent from the tree |
+| Routing forms | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | partial code present despite the upstream ❌ |
+
+### API keys are supported; the REST API is not
+
+These are different things and conflating them is the single most common misreading of
+this product.
+
+**API-key management is SUPPORTED.** Keys are created and revoked in the UI, stored as a
+SHA-256 hash, and honoured today by the web-based automation integrations — Zapier and
+Make — which run inside the web runtime.
+
+**REST API v2 is PLANNED.** The API v2 application exists in the repository, but the
+published release is a single web runtime and does not ship it. A `/api/v2` path on a
+current deployment does not reach a working API.
+
+So the UI statement *"API keys allow other apps to communicate with cal.forte"* is
+accurate. *"cal.forte offers a public REST API"* is not, yet. See
+[roadmap/api-v2.md](roadmap/api-v2.md).
+
+## Analytics and enterprise
+
+| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Insights dashboard | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | absent from the tree |
+| Attributes and segments, delegation, workspace platform, admin panel | ✅ | ❌ | **NOT INCLUDED** | — | enterprise capabilities |
+| Ad-click tracking | ✅ | — | **NOT INCLUDED** | REVIEWED | removed by the fork |
+| Usage telemetry | ✅ | — | **NOT INCLUDED** | REVIEWED | removed by the fork; a CI guard prevents reintroduction |
+
+## Operations
+
+| Capability | cal.forte status | Verification | Notes |
+| --- | --- | --- | --- |
+| Database migrations | **SUPPORTED** | RUNTIME VERIFIED | applied automatically at start — [details](operations/database-migrations.md) |
+| Scheduled / background jobs | **LIMITED** | CODE VERIFIED | no scheduler ships in the container — [details](operations/cron-jobs.md) |
+| AMD64 and ARM64 images | **SUPPORTED** | RUNTIME VERIFIED | per-architecture tags, each runtime-tested natively |
+| Build provenance and SBOM | **SUPPORTED** | RUNTIME VERIFIED | per released digest |
+| Multi-architecture manifest | **NOT INCLUDED** | — | architecture-specific tags only |
+
+## How a row changes
+
+A capability moves to **SUPPORTED** only when evidence shows the *user workflow* working
+end to end — not when the code exists, and not when upstream claims it.
+
+| Change | Required evidence |
+| --- | --- |
+| → SUPPORTED | the supported user workflow demonstrated end to end, and the release that contains it identified |
+| → LIMITED | the constraint documented, with the finding or design decision it follows from |
+| → PLANNED | a roadmap page describing what must be resolved first |
+| → NOT INCLUDED | confirmation of absence, and the reason |
+| EVALUATING → anything | the evidence that closed the gap |
+
+The technical inventory behind these rows is
+[SELF_HOST_CAPABILITY_AUDIT.md](../SELF_HOST_CAPABILITY_AUDIT.md), which uses a finer
+evidence vocabulary (`E1` code-confirmed, `E2` reproduced, `E3` corroborated). That audit
+is the evidence layer; this page is the product layer. When they disagree, the audit is
+the fact and this page needs correcting.
+
+The intended flow is one-directional, so there is exactly one place to change:
+
+```
+technical audit / evidence
+  → this capability matrix (canonical)
+    → README "at a glance" summary
+    → feature-specific documentation
+```
+
+**Proposed, not implemented:** a CI check asserting that every capability named in the
+README summary also appears here with the same status, so the landing page cannot drift
+from this registry. It would fit alongside the existing fork guards in `forte-ci`.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,68 @@
+# Configuration
+
+cal.forte is configured entirely through environment variables. This page covers what you
+must set and what is worth knowing; it is not an exhaustive list of every upstream
+variable.
+
+The shipped `.env.example` in the repository root remains the complete reference.
+
+## Required
+
+Four settings have no safe default.
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | PostgreSQL connection string |
+| `NEXTAUTH_SECRET` | signs sessions |
+| `CALENDSO_ENCRYPTION_KEY` | encrypts stored third-party credentials |
+| `NEXT_PUBLIC_WEBAPP_URL` | the public URL of the instance |
+
+Generate the secrets with a real random source:
+
+```bash
+openssl rand -base64 32
+```
+
+**`CALENDSO_ENCRYPTION_KEY` is not rotatable in place.** Every stored integration
+credential is encrypted with it. If you lose it, those credentials cannot be decrypted and
+every connected calendar and conferencing account must be reconnected. Back it up with the
+same care as the database.
+
+`NEXT_PUBLIC_WEBAPP_URL` is partly baked into the image at build time and substituted at
+container start. Setting it to something other than the URL users actually reach produces
+subtle breakage in links and callbacks rather than an obvious failure.
+
+## Strongly recommended
+
+| Variable | Value | Why |
+| --- | --- | --- |
+| `NEXT_PUBLIC_DISABLE_SIGNUP` | `true` | an instance you operate for yourself has no reason to accept public registrations |
+| `CRON_API_KEY` | a generated secret | protects the scheduled-job endpoints — see [Background jobs](operations/cron-jobs.md) |
+
+## Notable behaviour
+
+**App-store apps are disabled until credentialed.** Integrations do not become active by
+being present in the image; each requires its own credentials. See
+[Integrations](integrations.md).
+
+**Advertising and telemetry defaults differ from upstream.** The fork removes usage
+telemetry outright and disables advertising integrations by default. This is not a setting
+you need to find — it is the shipped default, recorded in
+[FORK_DIVERGENCE.md](../../FORK_DIVERGENCE.md).
+
+**Some upstream variables control nothing in this fork.** Upstream configuration surfaces
+survive stripping even when their implementation does not. If a variable you found in
+upstream documentation appears to have no effect, that is plausible; check
+[FORK_DIVERGENCE.md](../../FORK_DIVERGENCE.md) and
+[SELF_HOST_CAPABILITY_AUDIT.md](../SELF_HOST_CAPABILITY_AUDIT.md) before assuming
+misconfiguration.
+
+**Content Security Policy depends on your deployment.** The application can emit CSP in
+report-only mode; whether it is enforced is a deployment policy decision, not a product
+default.
+
+## Secrets handling
+
+Prefer file-based secrets over environment variables where your deployment supports it,
+and never bake secrets into an image. The [deployment contract](deployment.md) states what
+the product requires; how secrets are delivered is the deployment's decision.

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1,0 +1,101 @@
+# Deployment contract
+
+What cal.forte requires from a deployment. **This page deliberately contains no
+deployment instructions.**
+
+Provider guides, host hardening, reverse-proxy setup, firewalling, backup and monitoring
+are the responsibility of
+[Secure Docker Blueprint](https://github.com/rubennati/secure-docker-blueprint), which is
+the production deployment source of truth. Duplicating that here would create two
+documents that disagree.
+
+What follows is the product contract a deployment implementation must satisfy.
+
+## Runtime services
+
+| Service | Required | Notes |
+| --- | --- | --- |
+| cal.forte web application | yes | the published image; a single runtime |
+| PostgreSQL | yes | the application owns its schema |
+| Redis | yes | |
+| Scheduler | **conditional** | required for scheduled work — [Background jobs](operations/cron-jobs.md) |
+| API service | no | none is shipped — [roadmap](roadmap/api-v2.md) |
+
+## Interfaces
+
+| | |
+| --- | --- |
+| Application port | `3000` |
+| Public interface | HTTP, behind a TLS-terminating reverse proxy |
+| Direct host port exposure | not required, and not recommended |
+
+The application expects to be reached at `NEXT_PUBLIC_WEBAPP_URL`. Serving it at a
+different externally visible URL produces broken links and callbacks rather than an
+obvious failure.
+
+## Persistent state
+
+| State | Where |
+| --- | --- |
+| All application data | PostgreSQL |
+| Cache and transient state | Redis |
+
+The container itself holds no durable state. Back up the database; the container is
+replaceable.
+
+`CALENDSO_ENCRYPTION_KEY` is part of your backup surface — without it, credentials in the
+database cannot be decrypted.
+
+## Configuration and secrets
+
+Required: `DATABASE_URL`, `NEXTAUTH_SECRET`, `CALENDSO_ENCRYPTION_KEY`,
+`NEXT_PUBLIC_WEBAPP_URL`. Recommended: `CRON_API_KEY`, `NEXT_PUBLIC_DISABLE_SIGNUP`.
+
+Full detail in [Configuration](configuration.md). How secrets are delivered is the
+deployment's decision; file-based secrets are preferable to environment variables where
+supported.
+
+## Startup and migrations
+
+On start the container waits for the database, applies pending migrations, seeds the app
+store, then serves the application.
+
+Consequences a deployment must respect:
+
+- **Do not run two instances through a first start against the same database
+  simultaneously.** Migration is not coordinated between replicas.
+- The database must be reachable before the application is considered failed; the
+  container waits.
+- First start is slower than subsequent starts.
+
+See [Database migrations](operations/database-migrations.md).
+
+## Health
+
+The application serves HTTP once ready. A request to a public route returning `200` or a
+redirect is a sufficient readiness signal; the release pipeline uses exactly that against
+`/auth/login`.
+
+Allow generous startup time before declaring failure — migrations run first.
+
+## Supported architectures
+
+`linux/amd64` and `linux/arm64`, published as **separate tags**, each built and
+runtime-tested on native hardware.
+
+There is no combined multi-architecture manifest. A deployment must select the correct
+architecture tag explicitly.
+
+## Artifact selection
+
+Pin a **digest**, not a tag, and never `latest`. Current digests are recorded in
+[FORK_STATUS.md](../../FORK_STATUS.md); how images are built and what is asserted about
+them is in [IMAGE_BUILD.md](../../IMAGE_BUILD.md).
+
+Every released digest carries build provenance and a CycloneDX SBOM.
+
+## Outbound network
+
+The application needs outbound internet access for calendar providers, SMTP and OAuth.
+A full egress lockdown breaks integrations. This is a documented residual risk rather than
+something the product resolves.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,79 @@
+# Getting started
+
+This page gets one instance running. It does not cover production hardening — that is the
+deployment implementation's job, described in [Deployment contract](deployment.md).
+
+## What you need
+
+- a container runtime
+- PostgreSQL
+- Redis
+- a hostname you control, and TLS in front of it
+- outbound internet access from the application (calendars, SMTP, OAuth providers)
+
+cal.forte is published as **per-architecture image tags** for `linux/amd64` and
+`linux/arm64`. There is no combined multi-architecture manifest — pick the tag for your
+platform.
+
+## Get the current image reference
+
+Release tags and their digests are recorded in [FORK_STATUS.md](../../FORK_STATUS.md).
+They are deliberately not repeated here, so this page does not go stale.
+
+**Deploy by digest, not by tag, and never by `latest`.** A version tag identifies a
+release; a digest identifies the exact bytes that were tested. `latest` is a convenience
+pointer with no release meaning.
+
+```
+ghcr.io/rubennati/cal.diy:<version>@sha256:<digest>        # amd64
+ghcr.io/rubennati/cal.diy:<version>-arm@sha256:<digest>    # arm64
+```
+
+## Minimum configuration
+
+Four settings have no safe default and must be provided. Generating them is covered in
+[Configuration](configuration.md).
+
+| | |
+| --- | --- |
+| `DATABASE_URL` | PostgreSQL connection string |
+| `NEXTAUTH_SECRET` | session signing secret |
+| `CALENDSO_ENCRYPTION_KEY` | encrypts stored third-party credentials |
+| `NEXT_PUBLIC_WEBAPP_URL` | the public URL of your instance |
+
+Losing `CALENDSO_ENCRYPTION_KEY` makes every stored integration credential
+unrecoverable. Treat it as a secret you back up, not one you regenerate.
+
+## First start
+
+On start the container waits for the database, applies pending migrations, seeds the app
+store, and starts the web application on port `3000`. You do not run migrations yourself —
+see [Database migrations](operations/database-migrations.md).
+
+The first start is slower than later ones because migrations and seeding run.
+
+## Create the first account
+
+If self-registration is enabled, sign up through the UI. Then **disable it** —
+a scheduling instance you operate yourself has no reason to accept public registrations,
+and an open signup form is both an attack foothold and a spam surface:
+
+```
+NEXT_PUBLIC_DISABLE_SIGNUP=true
+```
+
+## Before you rely on it
+
+Two things are easy to miss and both are documented separately because they change what
+the product does for you:
+
+1. **[Background jobs](operations/cron-jobs.md)** — without an external scheduler,
+   reminder emails and calendar refresh never run.
+2. **[Capabilities](capabilities.md)** — particularly the difference between API keys
+   (supported) and a REST API (planned).
+
+## Next
+
+- [Configuration](configuration.md) — what else you can set
+- [Integrations](integrations.md) — connecting calendars and conferencing
+- [Security model](security.md) — what the product expects the deployment to provide

--- a/docs/guide/integrations.md
+++ b/docs/guide/integrations.md
@@ -1,0 +1,66 @@
+# Integrations
+
+## How integrations become active
+
+App-store applications ship in the image but are **inactive until credentialed**. Adding
+an integration means supplying its credentials, not installing anything.
+
+This is deliberate: an uncredentialed app has no configuration, no tokens and no outbound
+calls.
+
+## Calendars
+
+| Provider | Status |
+| --- | --- |
+| Google Calendar | SUPPORTED |
+| Outlook / Office 365 | SUPPORTED |
+| Apple Calendar, CalDAV | SUPPORTED |
+| Exchange, ICS feed | SUPPORTED |
+| Zoho Calendar | SUPPORTED — hardened by the fork |
+| Lark, Feishu | EVALUATING |
+
+**Zoho** carries a fork-specific change worth knowing. Upstream builds the Zoho API
+hostname from an OAuth parameter, which allowed a crafted value to redirect credentials to
+another host — and the value was persisted and reused on later token refreshes. cal.forte
+maps a closed set of regions to hostnames fixed at build time and refuses anything else.
+An unrecognised region is rejected rather than used. This also repairs upstream's `ca` and
+`cn` regions, which pointed at hostnames that do not exist.
+
+### Keeping calendars in sync
+
+Calendar subscription refresh is implemented as a **scheduled endpoint**, and the
+container ships no scheduler. Without an external trigger, subscriptions are not refreshed
+on a schedule. See [Background jobs](operations/cron-jobs.md).
+
+## Conferencing
+
+Cal Video (Daily.co), Zoom, Google Meet, Microsoft Teams, Webex and Jitsi are present and
+credential-driven. Recording is a commercial capability and is not included.
+
+## Automation
+
+| Integration | Status | Notes |
+| --- | --- | --- |
+| Webhooks (personal) | SUPPORTED | configured per user |
+| Zapier | SUPPORTED | authenticates with an API key |
+| Make | SUPPORTED | authenticates with an API key |
+| n8n, Pipedream | EVALUATING | present, not exercised |
+| Workflows | NOT INCLUDED | absent from the fork |
+
+Zapier and Make run **inside the web runtime**. This is why API keys are a working
+capability even though the REST API is not shipped — see
+[Authentication](authentication.md) and the [API v2 roadmap](roadmap/api-v2.md).
+
+## Intercom
+
+Present and hardened by the fork. Upstream served its configuration endpoint without
+authentication and validated the submitted booking link with a pattern whose unescaped
+dots matched hosts it should not have, then followed redirects. cal.forte verifies
+Intercom's documented request signature, refuses the request when the app is
+unconfigured, compares parsed URL components instead of a string pattern, and does not
+follow redirects.
+
+## Payments
+
+Stripe and PayPal apps are present and require provider credentials. Not exercised by this
+project's release validation — treat as EVALUATING.

--- a/docs/guide/operations/cron-jobs.md
+++ b/docs/guide/operations/cron-jobs.md
@@ -1,0 +1,72 @@
+# Background jobs
+
+**Read this before relying on reminders or calendar sync.**
+
+## The situation
+
+Several pieces of cal.forte functionality are implemented as **HTTP endpoints that
+something must call on a schedule**. The published container ships **no scheduler**. Its
+startup runs migrations, seeds the app store and starts the web application — nothing
+else.
+
+Upstream runs these on Vercel's cron scheduler, which is a hosting-platform feature and
+does not exist in a self-hosted container. The repository still contains that scheduler
+definition; it has no effect here.
+
+So on a default self-hosted deployment, **scheduled work does not run at all** until you
+arrange for it. Nothing fails loudly. Reminders simply never arrive.
+
+This is why the capability is classified **LIMITED** rather than SUPPORTED in the
+[capability matrix](../capabilities.md).
+
+## What is affected
+
+| Job | Effect if never called |
+| --- | --- |
+| Booking reminders | organiser reminder emails for pending bookings are not sent |
+| Calendar subscription refresh | subscriptions are not renewed on schedule |
+| Calendar subscription cleanup | stale subscriptions accumulate |
+| Selected-calendar refresh | connected-calendar state drifts |
+| Queued task processing | queued background work is not processed |
+| App metadata sync | app-store metadata is not refreshed |
+| Timezone change handling | scheduled timezone updates are not applied |
+
+Booking reminders are usually the one that matters first, because their absence looks like
+a product defect rather than a missing scheduler.
+
+## What you need to do
+
+Run an external scheduler that calls the endpoints over HTTP on a schedule. This can be
+anything that makes an authenticated HTTP request on a timer — a systemd timer, a cron
+container, or your platform's scheduler.
+
+Set `CRON_API_KEY` to a generated secret and have the scheduler present it. Endpoints
+reject unauthenticated requests.
+
+```bash
+openssl rand -hex 32
+```
+
+Frequencies should follow the upstream scheduler definition in the repository
+(`apps/web/vercel.json`) as a starting point — it records the intended cadence for each
+job even though the mechanism does not apply here.
+
+## Reaching the endpoints privately
+
+The scheduler does **not** have to reach cal.forte over the public internet. If it runs on
+the same internal network, it can call the application directly, and the scheduled
+endpoints then never need to be publicly routable at all.
+
+That is the preferable arrangement: it keeps the job endpoints off the public surface
+while preserving the supported workflow. Whether your deployment does this is a
+[Secure Docker Blueprint](https://github.com/rubennati/secure-docker-blueprint) concern,
+not a product setting.
+
+## Verifying
+
+After configuring the scheduler, confirm that an authenticated call returns success rather
+than `401` or `403`, and that a subsequent run has an observable effect — a pending
+booking old enough to qualify producing a reminder is the clearest signal.
+
+An unauthenticated call returning `401`/`403` is the correct, expected response and
+confirms the endpoint is reachable and protected.

--- a/docs/guide/operations/database-migrations.md
+++ b/docs/guide/operations/database-migrations.md
@@ -1,0 +1,35 @@
+# Database migrations
+
+## How they run
+
+Migrations are applied **automatically when the container starts**, before the application
+serves traffic. The startup sequence is: wait for the database → `prisma migrate deploy` →
+seed the app store → start.
+
+You do not run migrations manually. Upgrading the image is what applies them.
+
+## What this means in practice
+
+**Do not start two instances through a first start against the same database at the same
+time.** Migration is not coordinated between replicas. Bring one instance up, let it
+finish, then scale.
+
+**First start after an upgrade is slower.** The application is not broken; it is
+migrating. Set startup timeouts and health-check grace periods accordingly.
+
+**Migrations run forward only.** There is no automatic rollback. Rolling back to a
+previous image after a migration has applied is not supported by the schema — see
+[Upgrading](upgrading.md).
+
+## Before upgrading
+
+Back up the database. This is the only reliable way back from a migration you did not want.
+
+A database backup without `CALENDSO_ENCRYPTION_KEY` is not a complete backup: the stored
+third-party credentials cannot be decrypted without it.
+
+## The app-store seed
+
+Alongside migrations, start-up seeds app-store metadata. This registers which integrations
+exist; it does **not** enable them or supply credentials. An integration remains inactive
+until credentialed — see [Integrations](../integrations.md).

--- a/docs/guide/operations/troubleshooting.md
+++ b/docs/guide/operations/troubleshooting.md
@@ -1,0 +1,72 @@
+# Troubleshooting
+
+Symptoms in the order they are usually met.
+
+## Reminder emails never arrive
+
+Almost always the missing scheduler, not a mail problem. The container runs no scheduled
+jobs by itself — see [Background jobs](cron-jobs.md).
+
+Confirm mail separately by triggering a booking-confirmation email, which is sent
+directly rather than on a schedule. If confirmations arrive and reminders do not, it is
+the scheduler.
+
+## Calendars stop syncing after a while
+
+Subscription refresh is a scheduled job. Same cause as above.
+
+## `/api/v2/...` does not work
+
+Expected. The published release ships no REST API service; a `/api/v2` path does not reach
+a working API. This is not a misconfiguration you can fix with settings.
+
+API **keys** still work for the supported web integrations. See
+[the capability matrix](../capabilities.md) and the
+[API v2 roadmap](../roadmap/api-v2.md).
+
+## An integration is present but does nothing
+
+App-store apps are inactive until credentialed. Presence in the UI is not activation — see
+[Integrations](../integrations.md).
+
+## A setting from Cal.com documentation has no effect
+
+Plausible rather than surprising. Upstream configuration surfaces sometimes survive in the
+fork even where their implementation does not.
+
+Check [FORK_DIVERGENCE.md](../../../FORK_DIVERGENCE.md) and
+[SELF_HOST_CAPABILITY_AUDIT.md](../../SELF_HOST_CAPABILITY_AUDIT.md) before assuming you
+have misconfigured something.
+
+## Container will not start
+
+In order of likelihood:
+
+1. **Database unreachable.** The container waits for it and logs the wait.
+2. **A required variable is missing** — `DATABASE_URL`, `NEXTAUTH_SECRET`,
+   `CALENDSO_ENCRYPTION_KEY`, `NEXT_PUBLIC_WEBAPP_URL`.
+3. **Migrations still running.** First start after an upgrade takes noticeably longer;
+   check whether the health check is simply impatient.
+4. **Wrong architecture tag.** Images are per-architecture — see
+   [Deployment contract](../deployment.md).
+
+## Links or OAuth callbacks point to the wrong host
+
+`NEXT_PUBLIC_WEBAPP_URL` does not match the URL users actually reach. This produces
+subtly wrong behaviour rather than an error.
+
+## Integrations broke after restoring a backup
+
+`CALENDSO_ENCRYPTION_KEY` differs from the one in use when the credentials were stored.
+Stored credentials cannot be decrypted with a different key and must be reconnected.
+
+## Two-factor setup fails without explanation
+
+A known diagnosability defect —
+[#35](https://github.com/rubennati/cal.diy/issues/35).
+
+## Establishing what you are running
+
+The application exposes its exact version. For artifact-level verification, confirm the
+running digest against [FORK_STATUS.md](../../../FORK_STATUS.md) and verify its
+provenance — see [Upgrading](upgrading.md).

--- a/docs/guide/operations/upgrading.md
+++ b/docs/guide/operations/upgrading.md
@@ -1,0 +1,48 @@
+# Upgrading
+
+## The model
+
+An upgrade is: pull the new image digest, stop the old container, start the new one. The
+new container applies any pending migrations at start.
+
+There is no in-place update mechanism and no upgrade command.
+
+## Sequence
+
+1. **Read the release notes** for the version you are moving to. They state what changed
+   and what the release deliberately does not claim.
+2. **Back up the database**, and confirm you still hold `CALENDSO_ENCRYPTION_KEY`.
+3. **Select the digest** for your architecture from
+   [FORK_STATUS.md](../../../FORK_STATUS.md). Pin the digest, not the tag.
+4. **Start the new container.** Allow extra time for migrations.
+5. **Verify** that the login page loads and that a booking page renders.
+
+## Skipping versions
+
+Migrations are cumulative and applied in order, so moving across several releases at once
+generally works. The risk is not the migration mechanism but the size of the behavioural
+delta you absorb in one step, unreviewed. Prefer moving one release at a time when you
+can.
+
+## Rolling back
+
+**Rolling back the image does not roll back the database.** Once a migration has applied,
+an older image may not run against the new schema.
+
+A safe rollback is: restore the database backup taken before the upgrade, *and* start the
+previous image digest. Either alone is unreliable.
+
+The previous release digest is recorded as the rollback target in
+[FORK_STATUS.md](../../../FORK_STATUS.md).
+
+## Verifying what you are running
+
+The application exposes its exact version, which is the fastest way to confirm an upgrade
+took effect rather than a stale container still serving.
+
+For artifact-level verification, every released digest carries build provenance binding it
+to the source commit and tag:
+
+```bash
+gh attestation verify oci://ghcr.io/rubennati/cal.diy@sha256:<digest> --repo rubennati/cal.diy
+```

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -1,0 +1,44 @@
+# Overview
+
+cal.forte is a **hardened, review-gated fork of Cal.diy**, the MIT-licensed community
+edition of Cal.com. It exists so that scheduling software can be self-hosted on the public
+internet with a defensible answer to the question *"what exactly is running, and who
+reviewed it?"*
+
+It is not a rebrand and not a rewrite. The application is Cal.diy. What differs is how
+changes reach a running instance.
+
+## What the fork actually changes
+
+| | |
+| --- | --- |
+| **Review gate** | every upstream change is reviewed before integration; nothing is merged wholesale. Dispositions are recorded in [UPSTREAM_REVIEW_LEDGER.md](../../UPSTREAM_REVIEW_LEDGER.md) |
+| **Traceability** | each release names the exact source commit, source tree and image digests — see [FORK_STATUS.md](../../FORK_STATUS.md) |
+| **Reduced surface** | telemetry removed, advertising integrations off by default, self-registration disableable |
+| **Security fixes ahead of upstream** | several fixes in cal.forte are not in upstream Cal.diy; they are listed in [FORK_DIVERGENCE.md](../../FORK_DIVERGENCE.md) |
+| **Deploy by digest** | images are published per architecture with recorded digests and build provenance |
+
+## What it is not
+
+- **Not a Cal.com replacement with enterprise features.** Commercial and enterprise
+  functionality is not part of the MIT community edition and is not added here.
+- **Not a hosted service.** You run it.
+- **Not a general-purpose platform API host.** See [Capabilities](capabilities.md) and the
+  [API v2 roadmap](roadmap/api-v2.md).
+
+## Relationship to upstream
+
+Upstream Cal.diy documents itself as *"strictly recommended for personal, non-production
+use"*. cal.forte exists precisely because that recommendation is unsatisfying for someone
+who wants to self-host it anyway: the fork's answer is not to promise more, but to make
+the actual state auditable and to fix what it finds.
+
+That means some upstream claims do **not** carry over. Where this guide is silent about a
+feature you have read about in Cal.com's documentation, assume it is not supported here
+until [Capabilities](capabilities.md) says otherwise.
+
+## How to read this documentation
+
+Every capability is classified as **SUPPORTED**, **LIMITED** or **PLANNED**. Those words
+have precise meanings, defined in [Capabilities](capabilities.md). Nothing in this guide
+describes behaviour that is planned as though it already worked.

--- a/docs/guide/roadmap/api-v2.md
+++ b/docs/guide/roadmap/api-v2.md
@@ -1,0 +1,114 @@
+# REST API v2 — evaluation and roadmap
+
+**Status: PLANNED. Nothing on this page describes current runtime behaviour.**
+
+## Current state
+
+The API v2 application exists in this repository as a separate NestJS service. The
+published cal.forte release does **not** ship it: the release artifact is a single web
+runtime, which is also what [IMAGE_BUILD.md](../../../IMAGE_BUILD.md) records.
+
+Consequences today:
+
+- there is no cal.forte REST API endpoint you can call;
+- a `/api/v2` path on a current deployment does not reach a working API service;
+- the OpenAPI document in this repository is **not** a reference for a live cal.forte API.
+
+What does work: **API-key management, and the web integrations that consume keys** —
+Zapier and Make run inside the web runtime. See [Authentication](../authentication.md).
+API keys are not broken; the REST API is simply not part of the product yet.
+
+## Candidate architecture
+
+Evaluated, not built:
+
+```
+Web              https://<cal-forte-host>
+Potential API    https://api.<cal-forte-host>/v2
+```
+
+A **separate hostname** is preferred over a path under the web host. A distinct hostname
+allows routing, CORS policy, rate limiting, access logging, security middleware and the
+service's enable/disable lifecycle to be governed independently of the web application.
+
+Path routing under the web host would additionally inherit a build-time coupling: the web
+application's API path only exists when an API URL is configured at build time, so
+changing the API target would require rebuilding the web image. A separate host avoids
+that entirely.
+
+## What must be resolved before PLANNED becomes SUPPORTED
+
+Ordered roughly by dependency, not by effort.
+
+### Artifact
+
+- [ ] **Hardened API image.** The existing API Dockerfile builds in a single stage and
+      leaves the full monorepo source and build dependencies in the runtime layer. It
+      needs the same multi-stage treatment as the web image before it could be published.
+- [ ] **Second release image**, built independently — not a second runtime bolted into the
+      web image.
+- [ ] **AMD64 and ARM64**, each natively built and runtime-tested.
+- [ ] **Trivy scan, CycloneDX SBOM and build provenance** per architecture digest.
+- [ ] **`release-record.json` representation** covering both artifacts, so one release
+      record describes web and API together.
+
+### Authentication and authorization
+
+- [ ] **Authentication behaviour** confirmed end to end for keys created in the web UI.
+- [ ] **API-key prefix handling.** The configured prefix is currently only partly honoured
+      in the API application; a non-default prefix would break key recognition.
+- [ ] **Permission and scoping semantics.** An API key currently carries the full
+      authority of its owner, with no scope. Whether that is the intended contract for a
+      public API is a product decision, not an implementation detail.
+- [ ] **Authorization review** of the endpoints that would be exposed.
+
+### Service behaviour
+
+- [ ] **Rate limiting** policy for a public API surface.
+- [ ] **CORS and trusted origins.**
+- [ ] **Health and readiness** endpoints, and their startup semantics.
+- [ ] **Database and migration lifecycle.** The web application owns the schema; the API
+      service must not migrate, and must not start before migrations complete.
+- [ ] **Shared secrets and configuration**, including which secrets are shared with the
+      web application and which are its own.
+
+### Delivery
+
+- [ ] **Secure Docker Blueprint integration** — routing, network placement, secret
+      delivery and lifecycle, as a deployment concern rather than a product one.
+- [ ] **OpenAPI publication** — see below.
+
+## Acceptance criterion
+
+Retained for whoever picks this up:
+
+> A key created through the cal.forte UI must successfully authenticate to a supported
+> API v2 endpoint and resolve to the identity of the user who created the key.
+
+Identity resolution is part of the criterion, not an afterthought. A `200` response
+carrying a different user's data would be a failure, not a pass.
+
+## OpenAPI document
+
+`docs/api-reference/v2/openapi.json` is an OpenAPI 3.0 document describing the API v2
+application's controllers. It is generated from the NestJS controllers via the project's
+Swagger generation script, and is not hand-maintained.
+
+**It is a technical source, not a published API reference.** It describes the application
+in the repository, not a service cal.forte offers.
+
+Two gaps matter for future publication: the document declares no `servers` and no
+`securitySchemes`, so it does not yet state where the API lives or how to authenticate
+against it. Both would have to be correct before it could be rendered as user
+documentation.
+
+The intended future model:
+
+```
+OpenAPI document (generated from controllers)
+  → rendered API reference
+    → published only once API v2 becomes SUPPORTED
+```
+
+Endpoint lists are deliberately **not** duplicated into Markdown. A hand-maintained copy
+of a generated document drifts, and a drifted API reference is worse than none.

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -1,0 +1,71 @@
+# Security model
+
+What the product does, what it expects the deployment to do, and what it does not claim.
+
+## Division of responsibility
+
+cal.forte is an application. It is not a deployment platform, and it does not secure the
+host it runs on.
+
+| The product provides | The deployment must provide |
+| --- | --- |
+| authentication and session handling | TLS termination |
+| encryption of stored third-party credentials | a reverse proxy |
+| authorization within the application | network isolation and firewalling |
+| reviewed, digest-pinned release artifacts | rate limiting and WAF, if wanted |
+| build provenance and SBOMs | backups and monitoring |
+| a documented configuration contract | secret storage and delivery |
+
+The production deployment reference is
+[Secure Docker Blueprint](https://github.com/rubennati/secure-docker-blueprint). This
+documentation does not duplicate it.
+
+## What the fork changes relative to upstream
+
+The full register is [FORK_DIVERGENCE.md](../../FORK_DIVERGENCE.md). The security-relevant
+themes:
+
+- **Telemetry removed.** The inert usage-telemetry module and its opt-out flag are gone,
+  and a blocking CI guard prevents an upstream sync from reintroducing them.
+- **Advertising integrations disabled by default.**
+- **Trust boundaries repaired.** Several fixes exist in cal.forte that are not upstream —
+  Zoho server-location constraint, Intercom endpoint authentication, and a fail-closed
+  public slot lookup.
+- **Authorization fails closed.** Upstream's permission placeholders answer *yes*; the
+  fork's answer *no*, so a missing implementation cannot grant access.
+- **Release identity.** Images are published per architecture with recorded digests and
+  build provenance; deployments are expected to pin a digest.
+
+## What is verified, and what is not
+
+Being explicit about this matters more than a reassuring summary.
+
+| Verified per release | Not verified |
+| --- | --- |
+| the exact image runs and serves | penetration testing |
+| the MIT licence ships in the image, byte-identical | dynamic application security testing |
+| container image vulnerability scan **reported** | that all reported findings are fixed |
+| SBOM generated per architecture | that dependencies are free of unknown vulnerabilities |
+| build provenance attested per digest | |
+
+**Vulnerability scanners are report-only.** A green release does not mean the image
+contains no known vulnerabilities; it means the identity and regression gates passed.
+Accepted findings for a release are recorded in
+[SECURITY_REVIEW.md](../../SECURITY_REVIEW.md), and the reasoning for not blocking on
+scanner severity alone is in [SECURITY_ASSURANCE.md](../../SECURITY_ASSURANCE.md).
+
+## Known limitations that affect security posture
+
+- **API keys have no scope.** A key carries the full authority of its owner. Revocation is
+  the only control — see [Authentication](authentication.md).
+- **PBAC is not implemented.** It denies rather than grants, which is safe, but it means
+  no fine-grained permission model exists.
+- **Teams are not usable.** Team-scoped authorization gaps inherited from upstream have no
+  reachable path in a normal instance, because no shipped path creates a team.
+- **Scheduled endpoints are token-protected but externally invoked.** See
+  [Background jobs](operations/cron-jobs.md) and set `CRON_API_KEY`.
+
+## Reporting
+
+Security contact and process: [SECURITY.md](../../SECURITY.md). Reports go to the fork
+maintainer, not to upstream Cal.com.


### PR DESCRIPTION
cal.forte had extensive engineering, audit and release documentation but nowhere a *user* could learn what the product does. Answering "is this feature supported?" meant reading audit reports, release records or the code.

**Documentation only.** No application code, Docker behaviour, release workflow or runtime change. 15 files, all markdown.

## Structure

```
docs/README.md                              entry point
docs/guide/overview.md                      what cal.forte is
docs/guide/capabilities.md                  CANONICAL capability registry
docs/guide/getting-started.md
docs/guide/configuration.md
docs/guide/authentication.md                sign-in, sessions, API keys
docs/guide/integrations.md
docs/guide/security.md
docs/guide/deployment.md                    product contract, not a deployment guide
docs/guide/operations/database-migrations.md
docs/guide/operations/upgrading.md
docs/guide/operations/cron-jobs.md
docs/guide/operations/troubleshooting.md
docs/guide/roadmap/api-v2.md
```

No documentation framework introduced; the structure is suitable for one later.

## The capability matrix is the centre of this

Upstream feature tables answer one question with one tick: *does the product have X?* That is not enough for a fork, because a capability can exist in the codebase, be claimed by upstream documentation, and still not be usable in the release you are running.

Every row therefore answers **four separate questions**, never collapsed:

| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |

A tick in the Cal.diy column is an **inventory item to investigate**, not a statement about this fork.

Status vocabulary: `SUPPORTED` · `LIMITED` · `PLANNED` · `NOT INCLUDED` · `EVALUATING`.
Verification is **separate**, because a supported feature can still carry open findings: `RUNTIME VERIFIED` · `CODE VERIFIED` · `REVIEWED` · `OPEN FINDINGS` · `NOT YET VERIFIED`. No row is labelled "secure" — that is not a property this matrix can assert.

Where evidence was insufficient, the row says `EVALUATING` rather than guessing. Several upstream rows are marked that way rather than inheriting a claim.

## The contradiction this resolves

README listed API v2 under **"Present"**, while `IMAGE_BUILD.md` and the release artifact establish that no API runtime ships. That claim is gone. README now carries a "Capabilities at a glance" summary that points at the matrix rather than restating claims.

Two rows where upstream and the fork genuinely disagree, surfaced rather than smoothed over: `impersonation` and `routing-forms` have code present despite upstream marking them ❌ — both classified `EVALUATING`, because presence is not support.

## API keys — stated precisely

Describing API keys as broken because API v2 is absent would have been the opposite error to the one being fixed.

- **API-key management: SUPPORTED** — created and revoked in the UI, stored as a SHA-256 hash
- **Current consumers: Zapier and Make**, which run *inside the web runtime* and validate against the same hash
- **REST API v2: PLANNED** — the release ships no API service
- **OpenAPI: a technical source, not a published reference**

## Deployment boundary

`deployment.md` is a **product contract**: runtime services, interfaces, persistent state, configuration, startup/migration expectations, health, architectures. It contains no provider guides, host hardening, reverse-proxy setup, firewalling, backup or monitoring instructions — those reference Secure Docker Blueprint as the production source of truth.

## Background jobs

Own page, because the container ships **no scheduler** and nothing fails loudly when one is absent — reminders simply never arrive. This is why the capability is `LIMITED`, not `SUPPORTED`. The page also notes the scheduler can call the endpoints on the internal network, so they need not be publicly routable.

## Evidence flow

```
technical audit / evidence   (docs/SELF_HOST_CAPABILITY_AUDIT.md, E1/E2/E3)
  → capability matrix        (canonical product layer)
    → README summary
    → feature documentation
```

One-directional, so there is exactly one place to change. Existing audit and governance records are untouched and linked as the evidence layer.

**Proposed, not implemented:** a CI check asserting that every capability named in the README summary appears in the matrix with the same status, so the landing page cannot drift. It would fit alongside the existing fork guards.

## Checks

- 226 relative links across `docs/` verified — 0 broken
- all README links into `docs/` verified — 0 broken
- 0 non-markdown files in the diff
- release-specific values (tags, digests, dates) deliberately **not** repeated; they link to `FORK_STATUS.md` so the guide does not go stale between releases
- no deployment-specific hostnames, addresses, topology or certificate details
- the unresolved `CRON_SECRET` question is **not** present in the user documentation