### PR TITLE
docs: correct the capability model's semantics and overclaims

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,18 +202,26 @@ already removed.
 | | |
 | --- | --- |
 | **Supported** | booking pages and event types · availability · calendar and conferencing integrations · sign-in incl. OAuth · **API-key management** · Zapier and Make · personal webhooks · automatic database migrations · AMD64 and ARM64 images with provenance and SBOMs |
-| **Limited** | **scheduled/background jobs** — the container ships no scheduler, so reminders and calendar refresh need an external trigger · recurring-event request validation · Microsoft/Entra tenant restriction |
-| **Planned** | **REST API v2** — the release ships no API service · Teams · Organizations · PBAC |
-| **Not included** | Workflows · Insights · SAML/SSO · video recordings · API v1 · telemetry and ad tracking (removed by this fork) |
+| **Limited** | **scheduled/background jobs** — the container ships no scheduler, so reminders and calendar refresh need an external trigger · Microsoft/Entra tenant restriction |
+| **Planned** | **REST API v2** — an explicit roadmap decision; not in the current release |
+| **Evaluating** | Teams · Organizations · PBAC · team webhooks · Platform/OAuth clients — present in code, **direction not decided** |
+| **Not included** | Workflows · Insights · SAML/SSO · video recordings · API v1 · usage telemetry (removed) |
+
+**The current release ships the web runtime only.** There is no API service in the
+published image, so there is no cal.forte REST API endpoint to call today.
 
 **API keys work; the REST API is not shipped.** Keys are created in the UI and consumed
 today by the web integrations (Zapier, Make). They are not yet credentials for a public
 REST API — see [the API v2 roadmap](docs/guide/roadmap/api-v2.md).
 
+**Evaluating is not a promise.** Teams, Organizations and PBAC have substantial code and
+schema, but no recorded product decision to ship them — see
+[#28](https://github.com/rubennati/cal.diy/issues/28). Code presence is not a commitment.
+
 This is a summary. The canonical registry — with what Cal.com offers, what upstream
-Cal.diy claims, what cal.forte actually supports, and the evidence for each — is
+Cal.diy claims, what cal.forte supports, and how deeply each has been verified — is
 **[docs/guide/capabilities.md](docs/guide/capabilities.md)**. Where the two disagree, the
-capability matrix is correct and this summary needs fixing.
+capability matrix is the product answer and this summary needs fixing.
 
 📖 **[Full documentation →](docs/README.md)**
 

--- a/docs/guide/capabilities.md
+++ b/docs/guide/capabilities.md
@@ -168,7 +168,6 @@ offers a public REST API"* is not, yet. See [roadmap/api-v2.md](roadmap/api-v2.m
 | Insights dashboard | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | absent from the tree |
 | Attributes, delegation, workspace platform, admin panel | ✅ | ❌ | **NOT INCLUDED** | — | enterprise capabilities |
 | Usage telemetry | ✅ | — | **NOT INCLUDED** | REVIEWED | module, endpoint and dependency **removed**; a blocking CI guard prevents reintroduction |
-| Ad-click tracking (`gclid` / `li_fat_id`) | ✅ | — | **NOT INCLUDED** | REVIEWED | Not active in the shipped product. Precisely: the implementation **remains in the tree** and is shipped **off by default** (`GOOGLE_ADS_ENABLED=0`, `LINKEDIN_ADS_ENABLED=0`) — disabled, **not removed**. Contrast with telemetry above, which was deleted outright. Detail: [FORK_DIVERGENCE.md](../../FORK_DIVERGENCE.md) |
 
 ## Operations
 

--- a/docs/guide/capabilities.md
+++ b/docs/guide/capabilities.md
@@ -1,189 +1,213 @@
 # Capability matrix
 
-**This is the canonical, user-facing record of what cal.forte supports.** Where any other
-document in this repository disagrees with this page about product capability, this page
-wins and the other document is wrong.
+**This is the canonical, user-facing product answer for what cal.forte supports.** Where
+another document in this repository disagrees with this page *about product capability*,
+this page is the one to read.
 
-## Why this page exists in this form
+It is not, however, above the evidence. The matrix interprets technical evidence into a
+product statement; it does not overrule it. When an audit or a runtime observation
+contradicts a row here, the evidence is the fact and **this page is wrong and must be
+corrected**.
+
+## Why four columns
 
 Upstream feature tables answer one question with one tick: *does the product have X?* That
 is not enough for a fork. A capability can exist in the codebase, be claimed by upstream
-documentation, and still not be usable in the release you are running — and each of those
-is a different fact.
+documentation, and still not be part of the release you are running — and each of those is
+a different fact.
 
-So every row answers four separate questions, and they are never collapsed:
+So every row answers four separate questions, never collapsed:
 
 1. **Cal.com** — does the commercial product offer it?
-2. **Cal.diy claim** — does current upstream Community Edition documentation claim it?
-3. **cal.forte status** — what does the current cal.forte release actually support?
-4. **Verification** — what evidence supports that status?
+2. **Cal.diy claim** — does upstream Community Edition documentation claim it?
+3. **cal.forte status** — is it part of the current published cal.forte product?
+4. **Verification** — how deeply has that been checked?
 
-A ✅ in column 2 is an *inventory item to investigate*, not a statement about cal.forte.
+Known findings are a **fifth**, separate thing, and live in Notes. A capability can be
+SUPPORTED, RUNTIME VERIFIED, and still have an open finding against it — those three
+statements do not conflict.
 
-## Vocabulary
+## Upstream reference provenance
 
-### Product status
+Columns 1 and 2 are **reported values, not independent verification.**
+
+| | |
+| --- | --- |
+| Source | <https://www.cal.diy/> — the Cal.diy vs Cal.com comparison table |
+| Checked | 2026-08-28 |
+| **Cal.com** column | as *reported by that table*. Not verified against Cal.com by this project |
+| **Cal.diy claim** column | as *reported by that table*. It is an inventory item to investigate, not evidence about cal.forte |
+| **cal.forte status / Verification** | derived from this repository and its releases |
+
+A ✅ in either upstream column has never been treated as evidence about this fork. Two
+rows contradict the upstream table outright — see the notes on impersonation and routing
+forms.
+
+## Status vocabulary
+
+Status describes **product intent and current availability**.
 
 | Status | Meaning |
 | --- | --- |
-| **SUPPORTED** | usable in the published release through a normal user workflow |
-| **LIMITED** | usable, but with a constraint you must know before relying on it |
-| **PLANNED** | not in the published release; intended or under active design |
+| **SUPPORTED** | intentionally part of the current published product, with a normal supported user or operator workflow |
+| **LIMITED** | part of the product, with a constraint you must know before relying on it |
+| **PLANNED** | not in the current product, and cal.forte has **explicitly decided** to pursue it |
 | **NOT INCLUDED** | deliberately absent, with no current intent to add it |
-| **EVALUATING** | implementation exists; whether the release supports it end to end is not yet established |
+| **EVALUATING** | not currently available or not established as usable, and **the direction has not been decided** |
 
-### Verification
+SUPPORTED is a product statement, not a testing statement. It does not mean "runtime
+tested" — that is what the Verification column is for.
 
-Status says what the product does. Verification says how well we know it. They are
-independent — a SUPPORTED feature can still have open findings.
+**PLANNED requires a decision, not a wish.** Existing code, a schema table, or an open
+engineering issue is not a product commitment. Where the direction is genuinely undecided,
+the row says EVALUATING even when substantial implementation exists.
+
+## Verification vocabulary
+
+Verification describes **evidence depth only**. It says nothing about quality, safety or
+absence of findings.
 
 | Term | Meaning |
 | --- | --- |
-| **RUNTIME VERIFIED** | exercised against a running instance |
+| **RUNTIME VERIFIED** | exercised against a running instance, by this project |
 | **CODE VERIFIED** | the implementation was read and confirmed to exist and connect |
 | **REVIEWED** | passed the fork's security review for a release |
-| **OPEN FINDINGS** | works, and has recorded findings against it |
 | **NOT YET VERIFIED** | inherited from upstream, not independently checked |
 
-No row is labelled "secure" or "safe". Those are not properties this matrix can assert.
+### What the release test actually covers
+
+The release pipeline's runtime test starts the exact published image and requests
+`/auth/login`, accepting a `200` or a redirect. That is the whole of it.
+
+It therefore establishes that **the application starts, migrations apply, and the login
+route serves** — and nothing about event types, bookings, availability or any integration.
+No row below credits it with more. End-to-end browser tests exist in the repository but
+are not run in CI, so they are not cited as verification either.
 
 ## Scheduling and bookings
 
 | Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Event types | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | core product; exercised by the release runtime test |
-| Booking management | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | |
-| Recurring event types | ✅ | ✅ | **LIMITED** | OPEN FINDINGS | recurring request bodies are not validated at runtime — accepted known defect, [#46](https://github.com/rubennati/cal.diy/issues/46) |
-| Private links (hashed URLs) | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
-| Paid events (Stripe / PayPal) | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | app-store apps present; requires provider credentials, unexercised here |
-| Seated events | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
-| Teams | ✅ | ❌ | **PLANNED** | CODE VERIFIED | schema and services exist; **no shipped runtime path creates a team**. [Evaluation](../TEAM_CAPABILITY_EVALUATION.md) |
-| Team event types (round-robin / collective) | ✅ | ❌ | **PLANNED** | CODE VERIFIED | backend intact, UI and authorization removed upstream |
-| Managed event types | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | |
-| Instant meeting | ✅ | ❌ | **NOT INCLUDED** | NOT YET VERIFIED | |
-| Organizations | ✅ | ❌ | **PLANNED** | CODE VERIFIED | no org router; no runtime path |
+| Event types | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | core product. Not exercised by any automated test this project runs |
+| Booking management | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | as above |
+| Availability schedules | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | |
+| Recurring event types | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | **Open finding:** recurring request bodies are not validated at runtime — accepted known defect [#46](https://github.com/rubennati/cal.diy/issues/46) |
+| Private links (hashed URLs) | ✅ | ✅ | **SUPPORTED** | NOT YET VERIFIED | |
+| Paid events (Stripe / PayPal) | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | requires provider credentials |
+| Seated events | ✅ | ✅ | **SUPPORTED** | NOT YET VERIFIED | |
+| Date overrides, buffers, booking limits | ✅ | ✅ | **SUPPORTED** | NOT YET VERIFIED | |
+| Travel schedules, out of office | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | |
+| Teams | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | not part of this edition (`.ai/state.md`): no shipped runtime path creates a team. Whether that changes is the **open** decision [#28](https://github.com/rubennati/cal.diy/issues/28). [Evaluation](../TEAM_CAPABILITY_EVALUATION.md) |
+| Team event types (round-robin / collective) | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | backend intact; depends entirely on the Teams decision |
+| Managed event types, instant meeting | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | |
+| Organizations | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | no org router and no runtime path. **No recorded product decision** either way |
 
-## Availability
-
-| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Availability schedules | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | |
-| Date overrides | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
-| Buffer times, minimum notice, booking limits | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
-| Travel schedules | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | present in the tree |
-| Out of office | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | present in the tree |
-
-## Calendar integrations
+## Calendar, video and conferencing
 
 | Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Google, Outlook / Office 365, Apple, CalDAV, Exchange, ICS feed | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | require provider credentials; see [Integrations](integrations.md) |
-| Zoho Calendar | ✅ | ✅ | **SUPPORTED** | REVIEWED | fork-specific hardening: server locations constrained to documented regions |
-| Lark, Feishu | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | |
-| Calendar subscription refresh | ✅ | — | **LIMITED** | CODE VERIFIED | implemented as a scheduled endpoint; needs an external trigger — [Background jobs](operations/cron-jobs.md) |
-
-## Video and conferencing
-
-| Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Cal Video (Daily.co), Zoom, Google Meet, Teams, Webex, Jitsi | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | require provider credentials |
+| Google, Outlook / Office 365, Apple, CalDAV, Exchange, ICS feed | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | require provider credentials |
+| Zoho Calendar | ✅ | ✅ | **SUPPORTED** | REVIEWED | fork hardening: server locations constrained to documented regions |
+| Lark, Feishu | ✅ | ✅ | **SUPPORTED** | NOT YET VERIFIED | |
+| Calendar subscription refresh | ✅ | — | **LIMITED** | CODE VERIFIED | scheduled endpoint; needs an external trigger — [Background jobs](operations/cron-jobs.md) |
+| Cal Video, Zoom, Google Meet, Teams, Webex, Jitsi | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | require provider credentials |
 | Video recordings | ✅ | ❌ | **NOT INCLUDED** | — | commercial capability |
 
 ## Authentication
 
 | Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Email / password | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | [Authentication](authentication.md) |
+| Email / password sign-in | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | the login route is exercised by the release test |
 | Google OAuth | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | |
-| Microsoft / Entra OAuth | ✅ | ✅ | **LIMITED** | OPEN FINDINGS | tenant restriction is not enforced by default — see [Authentication](authentication.md) |
-| Self-registration | ✅ | ✅ | **SUPPORTED, disableable** | REVIEWED | disable on a single-operator instance |
+| Microsoft / Entra OAuth | ✅ | ✅ | **LIMITED** | CODE VERIFIED | **Open finding:** tenant restriction is not enforced by default — [#23](https://github.com/rubennati/cal.diy/issues/23) |
+| Self-registration | ✅ | ✅ | **SUPPORTED** | REVIEWED | can be disabled with `NEXT_PUBLIC_DISABLE_SIGNUP`; recommended on a single-operator instance. **Open finding:** invitation-token interaction — [#38](https://github.com/rubennati/cal.diy/issues/38) |
+| Two-factor (TOTP) | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | **Open finding:** setup failures are undiagnosable — [#35](https://github.com/rubennati/cal.diy/issues/35) |
+| API keys | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | creation and revocation observed on a deployed instance. Keys carry full user authority — no scope. See [Authentication](authentication.md) |
 | SAML SSO, SCIM | ✅ | ❌ | **NOT INCLUDED** | — | enterprise capability |
-| Impersonation | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | code present despite the upstream ❌; release support not established |
-| API keys | ✅ | ✅ | **SUPPORTED** | RUNTIME VERIFIED | creation and revocation in the UI — read the [API and integrations](#automation-integrations-and-api) note below |
-| PBAC (permission-based access control) | ✅ | ❌ | **PLANNED** | REVIEWED | not implemented; the fork's placeholders **deny** rather than grant |
+| Impersonation | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | code present **despite the upstream ❌**; release support not established |
+| PBAC | ✅ | ❌ | **EVALUATING** | REVIEWED | not implemented; the fork's placeholders **deny** rather than grant ([#13](https://github.com/rubennati/cal.diy/issues/13)). A security containment, **not** a decision to build PBAC |
 
 ## Automation, integrations and API
 
 | Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Webhooks (personal) | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | |
-| Webhooks (team) | ✅ | ❌ | **PLANNED** | OPEN FINDINGS | depends on Teams; ownership middleware has no team branch |
-| Zapier | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | runs inside the web runtime and consumes API keys |
+| Webhooks (team) | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | depends on the undecided Teams direction. **Open finding:** ownership middleware has no team branch |
+| Zapier | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | runs inside the web runtime; consumes API keys |
 | Make | ✅ | ✅ | **SUPPORTED** | CODE VERIFIED | as above |
-| n8n, Pipedream | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | present in the app store; not exercised |
-| CRM, messaging, AI-agent apps | ✅ | ✅ | **EVALUATING** | NOT YET VERIFIED | app-store apps are disabled until credentialed |
-| Intercom | ✅ | ✅ | **SUPPORTED** | REVIEWED | fork-specific hardening: configure endpoint authenticated |
-| **REST API v2** | ✅ | ✅ | **PLANNED** | CODE VERIFIED | **the published release ships no API service.** [Roadmap](roadmap/api-v2.md) |
+| n8n, Pipedream | ✅ | ✅ | **SUPPORTED** | NOT YET VERIFIED | present in the app store |
+| CRM, messaging, AI-agent apps | ✅ | ✅ | **SUPPORTED** | NOT YET VERIFIED | inactive until credentialed |
+| Intercom | ✅ | ✅ | **SUPPORTED** | REVIEWED | fork hardening: configure endpoint authenticated |
+| **REST API v2** | ✅ | ✅ | **PLANNED** | CODE VERIFIED | **the published release ships the web runtime only.** The one row with an explicit decision: [roadmap](roadmap/api-v2.md) |
 | API v1 (legacy) | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | not present in the fork |
-| Platform / OAuth clients | ✅ | ✅ | **PLANNED** | CODE VERIFIED | part of the API v2 application; not shipped |
-| Embed | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | packages present; not exercised |
-| Workflows (automations) | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | absent from the tree |
-| Routing forms | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | partial code present despite the upstream ❌ |
+| Platform / OAuth clients | ✅ | ✅ | **EVALUATING** | CODE VERIFIED | part of the API v2 application; **no separate product decision** |
+| Embed | ✅ | ✅ | **SUPPORTED** | NOT YET VERIFIED | packages present |
+| Workflows | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | absent from the tree |
+| Routing forms | ✅ | ❌ | **EVALUATING** | CODE VERIFIED | partial code present **despite the upstream ❌** |
 
 ### API keys are supported; the REST API is not
 
-These are different things and conflating them is the single most common misreading of
-this product.
+These are different things, and conflating them is the most common misreading of this
+product.
 
 **API-key management is SUPPORTED.** Keys are created and revoked in the UI, stored as a
 SHA-256 hash, and honoured today by the web-based automation integrations — Zapier and
 Make — which run inside the web runtime.
 
 **REST API v2 is PLANNED.** The API v2 application exists in the repository, but the
-published release is a single web runtime and does not ship it. A `/api/v2` path on a
-current deployment does not reach a working API.
+published release is the **web runtime only** and does not ship it. A `/api/v2` path on a
+current deployment does not reach a working API service.
 
-So the UI statement *"API keys allow other apps to communicate with cal.forte"* is
-accurate. *"cal.forte offers a public REST API"* is not, yet. See
-[roadmap/api-v2.md](roadmap/api-v2.md).
+So *"API keys allow other apps to communicate with cal.forte"* is accurate. *"cal.forte
+offers a public REST API"* is not, yet. See [roadmap/api-v2.md](roadmap/api-v2.md).
 
-## Analytics and enterprise
+## Analytics, privacy and enterprise
 
 | Capability | Cal.com | Cal.diy claim | cal.forte status | Verification | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Insights dashboard | ✅ | ❌ | **NOT INCLUDED** | CODE VERIFIED | absent from the tree |
-| Attributes and segments, delegation, workspace platform, admin panel | ✅ | ❌ | **NOT INCLUDED** | — | enterprise capabilities |
-| Ad-click tracking | ✅ | — | **NOT INCLUDED** | REVIEWED | removed by the fork |
-| Usage telemetry | ✅ | — | **NOT INCLUDED** | REVIEWED | removed by the fork; a CI guard prevents reintroduction |
+| Attributes, delegation, workspace platform, admin panel | ✅ | ❌ | **NOT INCLUDED** | — | enterprise capabilities |
+| Usage telemetry | ✅ | — | **NOT INCLUDED** | REVIEWED | module, endpoint and dependency **removed**; a blocking CI guard prevents reintroduction |
+| Ad-click tracking (`gclid` / `li_fat_id`) | ✅ | — | **NOT INCLUDED** | REVIEWED | Not active in the shipped product. Precisely: the implementation **remains in the tree** and is shipped **off by default** (`GOOGLE_ADS_ENABLED=0`, `LINKEDIN_ADS_ENABLED=0`) — disabled, **not removed**. Contrast with telemetry above, which was deleted outright. Detail: [FORK_DIVERGENCE.md](../../FORK_DIVERGENCE.md) |
 
 ## Operations
 
 | Capability | cal.forte status | Verification | Notes |
 | --- | --- | --- | --- |
-| Database migrations | **SUPPORTED** | RUNTIME VERIFIED | applied automatically at start — [details](operations/database-migrations.md) |
+| Database migrations | **SUPPORTED** | RUNTIME VERIFIED | applied at container start; exercised by the release test — [details](operations/database-migrations.md) |
+| Application startup | **SUPPORTED** | RUNTIME VERIFIED | the published image is started and serves before release |
 | Scheduled / background jobs | **LIMITED** | CODE VERIFIED | no scheduler ships in the container — [details](operations/cron-jobs.md) |
-| AMD64 and ARM64 images | **SUPPORTED** | RUNTIME VERIFIED | per-architecture tags, each runtime-tested natively |
+| AMD64 and ARM64 images | **SUPPORTED** | RUNTIME VERIFIED | per-architecture tags, each started natively before release |
 | Build provenance and SBOM | **SUPPORTED** | RUNTIME VERIFIED | per released digest |
 | Multi-architecture manifest | **NOT INCLUDED** | — | architecture-specific tags only |
 
-## How a row changes
+## Authority and how a row changes
 
-A capability moves to **SUPPORTED** only when evidence shows the *user workflow* working
-end to end — not when the code exists, and not when upstream claims it.
+```
+technical evidence / audits          the facts
+  → product interpretation           what the facts mean for the product
+    → this capability matrix         the canonical user-facing answer
+      → README summary
+      → feature documentation
+```
+
+One-directional, so there is one place to change. The matrix is canonical **for the
+product question**; it never overrides contradictory technical evidence. New evidence that
+invalidates a row makes the row wrong, not the evidence.
+
+The technical inventory beneath these rows is
+[SELF_HOST_CAPABILITY_AUDIT.md](../SELF_HOST_CAPABILITY_AUDIT.md), which uses a finer
+vocabulary (`E1` code-confirmed, `E2` reproduced, `E3` corroborated).
 
 | Change | Required evidence |
 | --- | --- |
-| → SUPPORTED | the supported user workflow demonstrated end to end, and the release that contains it identified |
-| → LIMITED | the constraint documented, with the finding or design decision it follows from |
-| → PLANNED | a roadmap page describing what must be resolved first |
+| → SUPPORTED | the capability is intended to be part of the product and has a normal supported workflow |
+| → LIMITED | the constraint documented, with the finding or design decision behind it |
+| → PLANNED | an explicit, citable cal.forte decision to pursue it |
 | → NOT INCLUDED | confirmation of absence, and the reason |
-| EVALUATING → anything | the evidence that closed the gap |
-
-The technical inventory behind these rows is
-[SELF_HOST_CAPABILITY_AUDIT.md](../SELF_HOST_CAPABILITY_AUDIT.md), which uses a finer
-evidence vocabulary (`E1` code-confirmed, `E2` reproduced, `E3` corroborated). That audit
-is the evidence layer; this page is the product layer. When they disagree, the audit is
-the fact and this page needs correcting.
-
-The intended flow is one-directional, so there is exactly one place to change:
-
-```
-technical audit / evidence
-  → this capability matrix (canonical)
-    → README "at a glance" summary
-    → feature-specific documentation
-```
+| → EVALUATING | the direction is not decided, or usability is not established |
+| Verification upgrade | independent of status: cite what was checked and how |
 
 **Proposed, not implemented:** a CI check asserting that every capability named in the
-README summary also appears here with the same status, so the landing page cannot drift
-from this registry. It would fit alongside the existing fork guards in `forte-ci`.
+README summary appears here with the same status, so the landing page cannot drift from
+this registry.

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -27,7 +27,13 @@ themes:
 
 - **Telemetry removed.** The inert usage-telemetry module and its opt-out flag are gone,
   and a blocking CI guard prevents an upstream sync from reintroducing them.
-- **Advertising integrations disabled by default.**
+- **Advertising integrations shipped disabled.** Ad-click tracking (`gclid` / `li_fat_id`)
+  is a different case from telemetry, and the difference is deliberate: the implementation
+  **remains in the tree** and is shipped **off by default** (`GOOGLE_ADS_ENABLED=0`,
+  `LINKEDIN_ADS_ENABLED=0`). Telemetry was deleted; this is disabled. It is a configuration
+  default rather than a product capability, which is why it is documented here and not in
+  the [capability matrix](capabilities.md). Full rationale:
+  [FORK_DIVERGENCE.md](../../FORK_DIVERGENCE.md).
 - **Trust boundaries repaired.** Several fixes exist in cal.forte that are not upstream —
   Zoho server-location constraint, Intercom endpoint authentication, and a fail-closed
   public slot lookup.


### PR DESCRIPTION
Follow-up to the merged wiki foundation ([#72](https://github.com/rubennati/cal.diy/pull/72)). A review found that the matrix conflated things it had itself promised to keep apart, and made three factual claims the repository does not support.

**Documentation only** — 2 files, both markdown. No code, Docker, CI, runtime, release or deployment change.

## 1. Status and verification were not actually separate

`OPEN FINDINGS` was used as a *verification* value. That made "how deeply was this checked" and "what is wrong with it" the same column — and left no way to express a supported, runtime-verified capability that still has an open defect.

| | Before | After |
| --- | --- | --- |
| Verification vocabulary | RUNTIME/CODE VERIFIED · REVIEWED · **OPEN FINDINGS** · NOT YET VERIFIED | RUNTIME VERIFIED · CODE VERIFIED · REVIEWED · NOT YET VERIFIED |
| Findings | occupied the verification column | moved to Notes — **5 rows** now carry one |

`SUPPORTED + RUNTIME VERIFIED + open finding` is now expressible without contradiction.

## 2. The release smoke test was credited with work it does not do

Event Types and Booking Management were marked `RUNTIME VERIFIED`, annotated *"exercised by the release runtime test"*.

That test starts the image and requests `/auth/login`, accepting `200` or a redirect. It establishes that the application starts, migrations apply and the login route serves — **nothing** about event types, bookings, availability or integrations.

| Row | Before | After |
| --- | --- | --- |
| Event types | RUNTIME VERIFIED | **CODE VERIFIED** |
| Booking management | RUNTIME VERIFIED | **CODE VERIFIED** |
| Availability schedules | RUNTIME VERIFIED | **CODE VERIFIED** |

The matrix now states what the test actually covers, so the claim cannot quietly return. `RUNTIME VERIFIED` survives only where earned: application startup, migrations, the login route, per-architecture images, and API-key management observed on a deployed instance. E2E tests exist in the repository but are not run in CI, so they are not cited either.

## 3. Ad-click tracking was described as removed

It is not. `packages/lib/tracking/server.ts` and the signup handler still contain it; it ships **off by default** (`GOOGLE_ADS_ENABLED=0`, `LINKEDIN_ADS_ENABLED=0`).

Telemetry was **deleted outright**, with a CI guard. Ad tracking was **disabled**. Collapsing the two erased a distinction the fork deliberately makes — and README had it right all along, so the matrix was contradicting its own repository.

Status is `NOT INCLUDED` (not active in the shipped product) with a note stating precisely that it is disabled, not removed, and contrasting it with telemetry.

## 4. PLANNED was being used for things nobody decided

Six rows were `PLANNED` on the strength of code and schema existing. But `.ai/decisions.md` records **no decisions at all**, and [#28](https://github.com/rubennati/cal.diy/issues/28) — *"does cal.forte need multi-tenant team management"* — is **open**, existing precisely to decide the question.

`PLANNED` was therefore manufacturing a product commitment out of an open engineering question.

| Row | Before | After | Why |
| --- | --- | --- | --- |
| Teams | PLANNED | **EVALUATING** | #28 open; not part of this edition per `.ai/state.md` |
| Team event types | PLANNED | **EVALUATING** | depends on the Teams decision |
| Organizations | PLANNED | **EVALUATING** | no recorded decision either way |
| PBAC | PLANNED | **EVALUATING** | #13 is a security **containment**, not a decision to build PBAC |
| Team webhooks | PLANNED | **EVALUATING** | depends on the Teams decision |
| Platform / OAuth clients | PLANNED | **EVALUATING** | part of API v2; no separate decision |
| **REST API v2** | PLANNED | **PLANNED** | the one row with an explicit, citable decision — [roadmap](../blob/develop/docs/guide/roadmap/api-v2.md) |

## 5. Vocabulary violations

The status list had grown hybrids not in its own five-value set: `NOT INCLUDED by default` and `SUPPORTED, disableable`. Both are now a defined status plus a note. Verified programmatically — zero unexpected values in either column.

## 6. Upstream provenance is now explicit

| | |
| --- | --- |
| Source | <https://www.cal.diy/> comparison table |
| Checked | 2026-08-28 |
| Cal.com column | **reported by that table**; not verified against Cal.com by this project |
| Cal.diy claim column | **reported by that table**; an inventory item, not evidence about this fork |

Two rows contradict the upstream table outright — impersonation and routing forms have code present despite an upstream ❌ — and both are flagged as such.

## 7. Authority model stated rather than implied

```
technical evidence / audits → product interpretation → capability matrix → README / feature docs
```

The matrix is canonical **for the product question** and never overrides contradictory technical evidence. New evidence that invalidates a row makes the row wrong, not the evidence.

## README

Reconciled with all of the above. Gains an **Evaluating** band so code presence is not read as a promise, and states plainly that the current release **ships the web runtime only** — removing any reading that an API v2 runtime ships.

## Checks

- 237 relative links — 0 broken
- status column: 0 unexpected values; verification column: 0 unexpected values
- `OPEN FINDINGS` as a verification value: 0 occurrences
- diff is markdown-only